### PR TITLE
Removing network error expectation warning

### DIFF
--- a/spec/spec_support/verify_network.rb
+++ b/spec/spec_support/verify_network.rb
@@ -12,6 +12,7 @@ module VerifyNetwork
       array.each do |obj|
         text += "\n\tStatus: #{obj.fetch(:status)}\tURL: #{obj.fetch(:url)}"
       end
+      text
     end
     @@log.info "Verify Network traffic"
     failed_resources = []


### PR DESCRIPTION
The following warning was in the STDOUT. It may have been getting lost
in the chatter of the other logged messages.

```console
WARNING: ignoring the provided expectation message argument ([]) since
it is not a string or a proc.
```