### PR TITLE
Removing explicit require

### DIFF
--- a/spec/honeycomb/integration/int_honeycomb_spec.rb
+++ b/spec/honeycomb/integration/int_honeycomb_spec.rb
@@ -1,7 +1,4 @@
 # frozen_string_literal: true
-require 'airborne'
-require 'rspec'
-
 describe 'Step 1: Collections endpoint' do
   it 'returns a response' do
     get 'https://honeycombpprd-vm.library.nd.edu/v1/collections'


### PR DESCRIPTION
These are not necessary as they are required as part of the Gemfile
declarations.