### PR TITLE
Adding auto-logging for click and visit activity

### DIFF
--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -17,30 +17,24 @@ feature 'User Browsing', js: true do
   end
 
   scenario 'Test start: Go to About page' do
-    log.info RSpec.current_example.description
     visit '/'
     click_on('About')
     about_page = Curate::Pages::AboutPage.new
     expect(about_page).to be_on_page
-    log.info "Test complete: Go to About page"
   end
 
   scenario 'Test start: Go to FAQ page' do
-    log.info RSpec.current_example.description
     visit '/'
     click_on('FAQ')
     faq_page = Curate::Pages::FaqPage.new
     expect(faq_page).to be_on_page
-    log.info 'Test complete: Go to FAQ page'
   end
 
   scenario 'Test 6a: Go to catalog search page with empty search term' do
-    log.info RSpec.current_example.description
     visit '/'
     click_on('Search')
     catalog_page = Curate::Pages::CatalogPage.new({})
     expect(catalog_page).to be_on_page
-    print "Clicked empty search\n"
   end
 
   scenario 'Test 6b: Go to catalog search page with term "Article"' do
@@ -50,72 +44,56 @@ feature 'User Browsing', js: true do
     click_on('Search')
     catalog_page = Curate::Pages::CatalogPage.new(search_term: search_term)
     expect(catalog_page).to be_on_page
-    print "Clicked search for #{search_term}\n"
     click_on('Clear all')
     expect(catalog_page).to be_on_base_url
-    print "Clicked on clear all\n"
   end
 
   scenario 'Test 6c: Category search for Theses' do
-    log.info RSpec.current_example.description
     visit '/'
     title = 'Theses & Dissertations'
     click_on(title)
     category_page = Curate::Pages::CatalogPage.new(category: :thesis)
     expect(category_page).to be_on_page
-    print "Clicked '#{title}' Link\n"
     click_on('Clear all')
     expect(category_page).to be_on_base_url
-    print "Clicked on clear all\n"
   end
 
   scenario 'Test 6d: Category search for Articles' do
-    log.info RSpec.current_example.description
     visit '/'
     title = 'Articles & Publications'
     click_on(title)
     category_page = Curate::Pages::CatalogPage.new(category: :article)
     expect(category_page).to be_on_page
-    print "Clicked '#{title}' Link\n"
     click_on('Clear all')
     expect(category_page).to be_on_base_url
-    print "Clicked on clear all\n"
   end
 
   scenario 'Test 6e: Category search for Datasets' do
-    log.info RSpec.current_example.description
     visit '/'
     title = 'Datasets & Related Materials'
     click_on(title)
     category_page = Curate::Pages::CatalogPage.new(category: :dataset)
     expect(category_page).to be_on_page
-    print "Clicked '#{title}' Link\n"
     click_on('Clear all')
     expect(category_page).to be_on_base_url
-    print "Clicked on clear all\n"
   end
 
   scenario 'Test 7: Contribute Your Work' do
     visit '/'
     click_on('Contribute Your Work')
-    print "Testing #{current_url}\n"
     contribute_page = Curate::Pages::ContributePage.new
     expect(contribute_page).to be_on_page
-    print "Clicked Contribute Your Work\n"
   end
 
   scenario 'Test 8: Materials by Department link' do
-    log.info RSpec.current_example.description
     visit '/'
     click_on('Materials by Department')
     dept_page = Curate::Pages::DepartmentsPage.new
     expect(dept_page).to be_on_page
-    print "Clicked 'Materials by Department' Link\n"
     departmental_link = dept_page.select_random_departmental_link
     dept_search_page = Curate::Pages::CatalogPage.new(category: :department, departmental_link: departmental_link)
     visit departmental_link.link
     expect(dept_search_page).to be_on_page
-    print "Clicked department search for #{departmental_link.caption}\n"
   end
 end
 
@@ -123,7 +101,6 @@ feature 'Requesting Help', js: true do
   scenario 'Test 1: Go to help page' do
     visit '/'
     click_on('Help')
-    print "Testing #{current_url}\n"
     help_page = Curate::Pages::ModalHelpPage.new
     expect(help_page).to be_on_page
     fill_in('help_request_name', with: 'some name')

--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -11,7 +11,6 @@ feature 'User Browsing', js: true do
   scenario 'Test start: Load Homepage' do
     log.info RSpec.current_example.description
     visit '/'
-    log.info current_url
     home_page = Curate::Pages::HomePage.new
     expect(home_page).to be_on_page
     log.info "Test complete: Load Homepage"
@@ -21,7 +20,6 @@ feature 'User Browsing', js: true do
     log.info RSpec.current_example.description
     visit '/'
     click_on('About')
-    log.info current_url
     about_page = Curate::Pages::AboutPage.new
     expect(about_page).to be_on_page
     log.info "Test complete: Go to About page"
@@ -31,7 +29,6 @@ feature 'User Browsing', js: true do
     log.info RSpec.current_example.description
     visit '/'
     click_on('FAQ')
-    log.info current_url
     faq_page = Curate::Pages::FaqPage.new
     expect(faq_page).to be_on_page
     log.info 'Test complete: Go to FAQ page'
@@ -41,7 +38,6 @@ feature 'User Browsing', js: true do
     log.info RSpec.current_example.description
     visit '/'
     click_on('Search')
-    log.info current_url
     catalog_page = Curate::Pages::CatalogPage.new({})
     expect(catalog_page).to be_on_page
     print "Clicked empty search\n"
@@ -52,7 +48,6 @@ feature 'User Browsing', js: true do
     search_term = "Article"
     fill_in('catalog_search', with: search_term)
     click_on('Search')
-    log.info current_url
     catalog_page = Curate::Pages::CatalogPage.new(search_term: search_term)
     expect(catalog_page).to be_on_page
     print "Clicked search for #{search_term}\n"
@@ -66,7 +61,6 @@ feature 'User Browsing', js: true do
     visit '/'
     title = 'Theses & Dissertations'
     click_on(title)
-    log.info current_url
     category_page = Curate::Pages::CatalogPage.new(category: :thesis)
     expect(category_page).to be_on_page
     print "Clicked '#{title}' Link\n"
@@ -80,7 +74,6 @@ feature 'User Browsing', js: true do
     visit '/'
     title = 'Articles & Publications'
     click_on(title)
-    log.info current_url
     category_page = Curate::Pages::CatalogPage.new(category: :article)
     expect(category_page).to be_on_page
     print "Clicked '#{title}' Link\n"
@@ -94,7 +87,6 @@ feature 'User Browsing', js: true do
     visit '/'
     title = 'Datasets & Related Materials'
     click_on(title)
-    log.info current_url
     category_page = Curate::Pages::CatalogPage.new(category: :dataset)
     expect(category_page).to be_on_page
     print "Clicked '#{title}' Link\n"
@@ -116,14 +108,12 @@ feature 'User Browsing', js: true do
     log.info RSpec.current_example.description
     visit '/'
     click_on('Materials by Department')
-    log.info current_url
     dept_page = Curate::Pages::DepartmentsPage.new
     expect(dept_page).to be_on_page
     print "Clicked 'Materials by Department' Link\n"
     departmental_link = dept_page.select_random_departmental_link
     dept_search_page = Curate::Pages::CatalogPage.new(category: :department, departmental_link: departmental_link)
     visit departmental_link.link
-    log.info current_url
     expect(dept_search_page).to be_on_page
     print "Clicked department search for #{departmental_link.caption}\n"
   end

--- a/spec/spec_support/current_example.rb
+++ b/spec/spec_support/current_example.rb
@@ -1,0 +1,84 @@
+class CurrentExample
+  DEFAULT_ENVIRONMENT = 'prod'
+
+  attr_reader :application_name_under_test, :spec_sub_directory, :spec_helper_path, :config, :environment_under_test, :example
+
+  def initialize(example:, config: ENV)
+    @example = example
+    @config = config
+    @environment_under_test = config.fetch('ENVIRONMENT', DEFAULT_ENVIRONMENT)
+    @spec_helper_path = File.expand_path('../../', __FILE__)
+    @current_logger = CurrentLogger.new(example: self)
+    initialize_example_variables!
+    initialize_app_host!
+  end
+
+  def run(&block)
+    @current_logger.info(context: "example", example: example.full_description, &block)
+  end
+
+  private
+
+  def initialize_example_variables!
+    spec_path = @example.metadata.fetch(:absolute_file_path)
+    @spec_sub_directory = spec_path.sub("#{spec_helper_path}/", '').split('/')
+    @application_name_under_test = spec_sub_directory.first
+  end
+
+  def initialize_app_host!
+    servers_by_environment = YAML.load_file(
+      File.expand_path("./#{application_name_under_test}/#{application_name_under_test}_config.yml", spec_helper_path)
+    )
+    Capybara.app_host = servers_by_environment.fetch(environment_under_test)
+  end
+end
+
+class CurrentLogger
+  def initialize(example:)
+    @example = example
+    initialize_logger!
+  end
+
+  def info(context:, **kwargs, &block)
+    log(severity: __method__, context: context, **kwargs, &block)
+  end
+  def debug(context:, **kwargs, &block)
+    log(severity: __method__, context: context, **kwargs, &block)
+  end
+  def fatal(context:, **kwargs, &block)
+    log(severity: __method__, context: context, **kwargs, &block)
+  end
+  def warn(context:, **kwargs, &block)
+    log(severity: __method__, context: context, **kwargs, &block)
+  end
+  def error(context:, **kwargs, &block)
+    log(severity: __method__, context: context, **kwargs, &block)
+  end
+
+  private
+
+  def initialize_logger!
+    @logger = Logging.logger[application_name_under_test]
+    Logging.appenders.stdout(layout: Logging.layouts.pattern(format_as: :json))
+
+    @logger.add_appenders('stdout')
+    @logger.level = :info
+  end
+
+  def application_name_under_test
+    @example.application_name_under_test
+  end
+
+  def log(severity:, context:, **kwargs, &block)
+    message = ""
+    kwargs.each_with_object(message) { |(key, value), obj| obj += %(#{key}: "#{value.inspect}") }
+
+    if block_given?
+      @logger.public_send(severity, %(context: "STARTING #{context}\t#{message}))
+      yield
+      @logger.public_send(severity, %(context: "STOPPING #{context}\t#{message}))
+    else
+      @logger.public_send(severity, %(context: #{context}\t#{message}))
+    end
+  end
+end

--- a/spec/spec_support/inject_current_url_logging.rb
+++ b/spec/spec_support/inject_current_url_logging.rb
@@ -1,0 +1,32 @@
+module InjectCurrentUrlLogging
+  def click(*args, &block)
+    super.tap {
+      Logging.logger['curate'].info(message_for(event: :click))
+    }
+  end
+
+  def submit(*args, &block)
+    super.tap {
+      Logging.logger['curate'].info(message_for(event: :submit))
+    }
+  end
+
+  def visit(*arg, &block)
+    super.tap {
+      Logging.logger['curate'].info(message_for(event: :visit))
+    }
+  end
+
+  private
+
+  def message_for(event:)
+     %(context: "#{event}"\tpath: "#{current_path}"\thost: "#{Capybara.app_host}"\t)
+  end
+end
+
+class Capybara::Poltergeist::Browser
+  include InjectCurrentUrlLogging
+end
+class Capybara::Poltergeist::Node
+  include InjectCurrentUrlLogging
+end

--- a/spec/spec_support/verify_network.rb
+++ b/spec/spec_support/verify_network.rb
@@ -14,7 +14,7 @@ module VerifyNetwork
       end
       text
     end
-    @@log.info "Verify Network traffic"
+    Logging.logger['curate'].info "Verify Network traffic"
     failed_resources = []
     page.driver.network_traffic.each do |request|
       request.response_parts.uniq(&:url).each do |response|


### PR DESCRIPTION
The goal of this addition is to automatically log the resulting URL of
all click, submit, and visit events.

This will in turn move the chatter of logging out of the scenario's
body, which should help improve the legibility. It will also

This is a step in addressing the general logging strategy that can
extend beyond the curate tests.