### PR TITLE
Begin logging examples to files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 tmp/*
+logs/*.log

--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -13,6 +13,7 @@ feature 'User Browsing:', js: true do
     click_on('About')
     about_page = Curate::Pages::AboutPage.new
     expect(about_page).to be_on_page
+    expect(true).to be_falsey
   end
 
   scenario 'Go to FAQ page' do


### PR DESCRIPTION
With this change, we begin logging the general chatter of the specs
along with the failures of those specs to the same log file.

At present, I am opting to write to both STDOUT and log files; This
way we can see how the specs look when they are run.

DLTP-747