### PR TITLE
Removing trailing tabs (\t)

### DIFF
--- a/spec/spec_support/example_logging.rb
+++ b/spec/spec_support/example_logging.rb
@@ -173,13 +173,12 @@ module ExampleLogging
       def log(severity:, context:, **kwargs)
         message = ""
         kwargs.each { |key, value| message += %(#{key}: #{value.inspect}\t) }
-        message = message.strip
         if block_given?
-          @current_logger.public_send(severity, %(test_type: #{test_type}\t context: "BEGIN #{context}\t#{message}))
+          @current_logger.public_send(severity, %(test_type: #{test_type}\t context: "BEGIN #{context}\t#{message}).strip)
           yield
-          @current_logger.public_send(severity, %(test_type: #{test_type}\t context: "END #{context}\t#{message}))
+          @current_logger.public_send(severity, %(test_type: #{test_type}\t context: "END #{context}\t#{message}).strip)
         else
-          @current_logger.public_send(severity, %(test_type: #{test_type}\t context: "#{context}"\t#{message}))
+          @current_logger.public_send(severity, %(test_type: #{test_type}\t context: "#{context}"\t#{message}).strip)
         end
       end
 


### PR DESCRIPTION
Prior to this change, if there were no keywords, the logged line would
have a trailing tab. This change fixes that.