### PR TITLE
Creating run ID for tracking test results

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,6 +43,10 @@ RSpec.configure do |config|
   config.order = :random
   Kernel.srand config.seed
 
+  config.before(:suite) do
+    RunIdentifier.set
+  end
+
   config.before(:example) do |rspec_example|
     @current_logger = ExampleLogging.start(example: rspec_example, config: ENV, test_handler: self)
   end

--- a/spec/spec_support/example_logging.rb
+++ b/spec/spec_support/example_logging.rb
@@ -200,11 +200,11 @@ module ExampleLogging
         message = ""
         kwargs.each { |key, value| message += %(#{key}: #{value.inspect}\t) }
         if block_given?
-          @current_logger.public_send(severity, %(test_type: #{test_type}\t context: "BEGIN #{context}\t#{message}).strip)
+          @current_logger.public_send(severity, %(test_type: #{test_type}\t runID: #{RunIdentifier.get}\t context: "BEGIN #{context}\t#{message}).strip)
           yield
-          @current_logger.public_send(severity, %(test_type: #{test_type}\t context: "END #{context}\t#{message}).strip)
+          @current_logger.public_send(severity, %(test_type: #{test_type}\t runID: #{RunIdentifier.get}\t context: "END #{context}\t#{message}).strip)
         else
-          @current_logger.public_send(severity, %(test_type: #{test_type}\t context: "#{context}"\t#{message}).strip)
+          @current_logger.public_send(severity, %(test_type: #{test_type}\t runID: #{RunIdentifier.get}\t context: "#{context}"\t#{message}).strip)
         end
       end
 

--- a/spec/spec_support/test_runtime.rb
+++ b/spec/spec_support/test_runtime.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module RunIdentifier
+  def self.set
+    @run_identifier = DateTime.now.strftime("%m%d%Y_%H%M%S.%L")
+  end
+
+  def self.get
+    @run_identifier
+  end
+end


### PR DESCRIPTION
Using the before(:suite) block to create a run ID based on datetime. 
After block is WIP