### PR TITLE
Ensuring bin/run_tests run outside of bundle exec

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby -wU
 # frozen_string_literal: true
 
-require File.expand_path('../../spec/spec_support/example_logging', __FILE__)
+require File.expand_path('../../spec/spec_support/example_logging_constants', __FILE__)
 
 # *****************************************************************************
 #

--- a/spec/spec_support/example_logging.rb
+++ b/spec/spec_support/example_logging.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'forwardable'
+require 'example_logging_constants'
 
 require 'capybara/node/element'
 class Capybara::Node::Element
@@ -21,10 +22,6 @@ end
 # It is intended to be included in the RSpec example context so as to expose
 # the @current_logger instance variable
 module ExampleLogging
-  DEFAULT_ENVIRONMENT = 'prod'
-  DEFAULT_LOG_LEVEL = 'info'
-  AVAILABLE_LOG_LEVELS = %w(debug info warn error fatal).freeze
-
   # Given that we want to send logs to different locations based on application,
   # we need to initialize different loggers. We also don't want to keep adding
   # appenders, so this is a means of instantiating all of those loggers before

--- a/spec/spec_support/example_logging_constants.rb
+++ b/spec/spec_support/example_logging_constants.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Extracted to separate location to assist in ./bin/run_tests to work.
+module ExampleLogging
+  DEFAULT_ENVIRONMENT = 'prod'
+  DEFAULT_LOG_LEVEL = 'info'
+  AVAILABLE_LOG_LEVELS = %w(debug info warn error fatal).freeze
+end


### PR DESCRIPTION
Prior to this change, when I ran `./bin/run_tests` I got the following
error. By extracting the constants to a separate file we can reference
the constants to assist in the help text of the `./bin/run_tests`
script.

```console
./ruby/gems/2.3.0/gems/capybara-2.12.1/lib/capybara/node/element.rb:24:in `<module:Node>': uninitialized constant Capybara::Node::Base (NameError)
	from ./ruby/gems/2.3.0/gems/capybara-2.12.1/lib/capybara/node/element.rb:3:in `<module:Capybara>'
	from ./ruby/gems/2.3.0/gems/capybara-2.12.1/lib/capybara/node/element.rb:2:in `<top (required)>'
	from ./ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:133:in `require'
	from ./ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:133:in `rescue in require'
	from ./ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:40:in `require'
	from /Users/jfriesen/git/QA_tests/spec/spec_support/example_logging.rb:4:in `<top (required)>'
	from ./ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from ./ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from ./bin/run_tests:4:in `<main>'
```