### PR TITLE
Fix for NameError: uninitialized constant

### DIFF
--- a/spec/spec_support/json_output_formatter.rb
+++ b/spec/spec_support/json_output_formatter.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'rspec/core/formatters/json_formatter'
+require 'rspec/core/formatters/console_codes'
 
 # This class injects custom variables by calling the same method of parent class JsonFormatter
 class JsonOutputFormatter < RSpec::Core::Formatters::JsonFormatter


### PR DESCRIPTION
Our custom JsonOutputFormatter is throwing a NameError for
ConsoleCodes core formatter module:
NameError: uninitialized constant RSpec::Core::Formatters::ConsoleCodes

This modules provides helpers for formatting console output