### PR TITLE
Jenkins job support for webRenovation project

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -12,7 +12,7 @@ set :deploy_via, :copy
 set :stages, ["staging", "production"]
 set :default_stage, "production"
 set :branch, 'master'
-set :tested_applications, ['curate', 'testApi']
+set :tested_applications, ['curate', 'testApi', 'webRenovation']
 set :target_env_for_test_application, ENV['TARGET']
 set :log_level_for_running_test, ENV['LOG_LEVEL']
 

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -8,7 +8,7 @@
 # server 'example.com', user: 'deploy', roles: %w{app web}, other_property: :other_value
 # server 'db.example.com', user: 'deploy', roles: %w{db}
 set :stage, :production
-server 'testcontroller01.library.nd.edu', roles: %w{curate testApi}, user: 'app'
+server 'testcontroller01.library.nd.edu', roles: %w{curate testApi webRenovation}, user: 'app'
 
 # role-based syntax
 # ==================


### PR DESCRIPTION
Jenkins job has an input parameter list for user to pick app name
to run tests against.

This variable is used by Capistrano as a server roles in
config/deploy/production.rb to determine which server the git repo
needs to be deployed to.

The same variable is used to set rspec command path in
run_test task