### PR TITLE
Test accounts behavior based on profile setup

### DIFF
--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -153,13 +153,156 @@ feature 'Facet Navigation', js: true do
   end
 end
 
-feature 'Logged In User Browsing', js: true do
+feature 'Logged In User (Account details NOT updated) Browsing', js: true do
   let(:login_page) {Curate::Pages::LoginPage.new(current_logger)}
   scenario "Log in" do
     login_page.completeLogin
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new
     expect(logged_in_home_page).to be_on_page
+  end
 
+  scenario "Manage My Works" do
+    login_page.completeLogin
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    expect(logged_in_home_page).to be_on_page
+    logged_in_home_page.openActionsDrawer
+    click_on("My Works")
+    works_page = Curate::Pages::MyWorksPage.new
+    expect(works_page).to be_on_page
+  end
+
+  scenario "Visit Manage My Groups page" do
+    login_page.completeLogin
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    expect(logged_in_home_page).to be_on_page
+    logged_in_home_page.openActionsDrawer
+    click_on("My Groups")
+    groups_page = Curate::Pages::MyGroupsPage.new
+    expect(groups_page).to be_on_page
+  end
+
+  scenario "Visit Manage My Collections page" do
+    login_page.completeLogin
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    expect(logged_in_home_page).to be_on_page
+    logged_in_home_page.openActionsDrawer
+    click_on("My Collections")
+    collections_page = Curate::Pages::MyCollectionsPage.new
+    expect(collections_page).to be_on_page
+  end
+
+  scenario "Visit Manage My Profile page" do
+    login_page.completeLogin
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    expect(logged_in_home_page).to be_on_page
+    logged_in_home_page.openActionsDrawer
+    click_on("My Profile")
+    profile_page = Curate::Pages::MyProfilePage.new
+    expect(profile_page).to be_on_page
+  end
+
+  scenario "Visit Manage My Delegates page" do
+    login_page.completeLogin
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    expect(logged_in_home_page).to be_on_page
+    logged_in_home_page.openActionsDrawer
+    click_on("My Delegates")
+    delegates_page = Curate::Pages::MyDelegatesPage.new
+    expect(delegates_page).to be_on_page
+  end
+
+  scenario "Visit Deposit New Article page" do
+    login_page.completeLogin
+    logged_in_home_page= Curate::Pages::LoggedInHomePage.new
+    expect(logged_in_home_page).to be_on_page
+    logged_in_home_page.openAddContentDrawer
+    click_on("New Article")
+    article_page = Curate::Pages::ArticlePage.new
+    expect(article_page).to be_on_page
+  end
+
+  scenario "Visit Deposit New Dataset page" do
+    login_page.completeLogin
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    expect(logged_in_home_page).to be_on_page
+    logged_in_home_page.openAddContentDrawer
+    click_on("New Dataset")
+    dataset_page = Curate::Pages::DatasetPage.new
+    expect(dataset_page).to be_on_page
+  end
+
+  scenario "Visit Deposit New Document page" do
+    login_page.completeLogin
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    expect(logged_in_home_page).to be_on_page
+    logged_in_home_page.openAddContentDrawer
+    click_on("New Document")
+    document_page = Curate::Pages::DocumentPage.new
+    expect(document_page).to be_on_page
+  end
+
+  scenario "Visit Deposit New Image page" do
+    login_page.completeLogin
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    expect(logged_in_home_page).to be_on_page
+    logged_in_home_page.openAddContentDrawer
+    click_on("New Image")
+    image_page = Curate::Pages::ImagePage.new
+    expect(image_page).to be_on_page
+  end
+
+  scenario "Visit More Options page" do
+    login_page.completeLogin
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    expect(logged_in_home_page).to be_on_page
+    logged_in_home_page.openAddContentDrawer
+    click_on("More Options")
+    options_page = Curate::Pages::StartDepositPage.new
+    expect(options_page).to be_on_page
+  end
+
+  scenario "Visit Deposit New Audio page" do
+    login_page.completeLogin
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    expect(logged_in_home_page).to be_on_page
+    logged_in_home_page.openAddContentDrawer
+    click_on("More Options")
+    options_page = Curate::Pages::StartDepositPage.new
+    expect(options_page).to be_on_page
+    find('.add-button.btn.btn-primary.add_new_audio').click
+    audio_page = Curate::Pages::AudioPage.new
+    expect(audio_page).to be_on_page
+  end
+
+  scenario "Visit Deposit New Senior Thesis page" do
+    login_page.completeLogin
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    expect(logged_in_home_page).to be_on_page
+    logged_in_home_page.openAddContentDrawer
+    click_on("More Options")
+    options_page = Curate::Pages::StartDepositPage.new
+    expect(options_page).to be_on_page
+    find('.add-button.btn.btn-primary.add_new_senior_thesis').click
+    thesis_page = Curate::Pages::ThesisPage.new
+    expect(thesis_page).to be_on_page
+  end
+
+  scenario "Log out" do
+    login_page.completeLogin
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    expect(logged_in_home_page).to be_on_page
+    logged_in_home_page.openActionsDrawer
+    click_on("Log Out")
+    login_page.checkLoginPage
+  end
+end
+
+feature 'Logged In User (Account details updated) Browsing', js: true do
+  let(:login_page) {Curate::Pages::LoginPage.new(current_logger)}
+  scenario "Log in" do
+    login_page.completeLogin
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    expect(logged_in_home_page).to be_on_page
   end
 
   scenario "Manage My Works" do

--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -154,16 +154,16 @@ feature 'Facet Navigation', js: true do
 end
 
 feature 'Logged In User (Account details NOT updated) Browsing', js: true do
-  let(:login_page) {Curate::Pages::LoginPage.new(current_logger)}
+  let(:login_page) {Curate::Pages::LoginPage.new(current_logger, account_details_updated?: false)}
   scenario "Log in" do
     login_page.completeLogin
-    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
   end
 
   scenario "Manage My Works" do
     login_page.completeLogin
-    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
     click_on("My Works")
@@ -173,7 +173,7 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
 
   scenario "Visit Manage My Groups page" do
     login_page.completeLogin
-    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
     click_on("My Groups")
@@ -183,7 +183,7 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
 
   scenario "Visit Manage My Collections page" do
     login_page.completeLogin
-    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
     click_on("My Collections")
@@ -193,7 +193,7 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
 
   scenario "Visit Manage My Profile page" do
     login_page.completeLogin
-    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
     click_on("My Profile")
@@ -203,7 +203,7 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
 
   scenario "Visit Manage My Delegates page" do
     login_page.completeLogin
-    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
     click_on("My Delegates")
@@ -213,7 +213,7 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
 
   scenario "Visit Deposit New Article page" do
     login_page.completeLogin
-    logged_in_home_page= Curate::Pages::LoggedInHomePage.new
+    logged_in_home_page= Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
     click_on("New Article")
@@ -223,7 +223,7 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
 
   scenario "Visit Deposit New Dataset page" do
     login_page.completeLogin
-    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
     click_on("New Dataset")
@@ -233,7 +233,7 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
 
   scenario "Visit Deposit New Document page" do
     login_page.completeLogin
-    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
     click_on("New Document")
@@ -243,7 +243,7 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
 
   scenario "Visit Deposit New Image page" do
     login_page.completeLogin
-    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
     click_on("New Image")
@@ -253,7 +253,7 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
 
   scenario "Visit More Options page" do
     login_page.completeLogin
-    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
     click_on("More Options")
@@ -263,7 +263,7 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
 
   scenario "Visit Deposit New Audio page" do
     login_page.completeLogin
-    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
     click_on("More Options")
@@ -276,7 +276,7 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
 
   scenario "Visit Deposit New Senior Thesis page" do
     login_page.completeLogin
-    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
     click_on("More Options")
@@ -289,7 +289,7 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
 
   scenario "Log out" do
     login_page.completeLogin
-    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
     click_on("Log Out")
@@ -298,16 +298,16 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
 end
 
 feature 'Logged In User (Account details updated) Browsing', js: true do
-  let(:login_page) {Curate::Pages::LoginPage.new(current_logger)}
+  let(:login_page) {Curate::Pages::LoginPage.new(current_logger, account_details_updated?: true)}
   scenario "Log in" do
     login_page.completeLogin
-    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
   end
 
   scenario "Manage My Works" do
     login_page.completeLogin
-    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
     click_on("My Works")
@@ -317,7 +317,7 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
 
   scenario "Visit Manage My Groups page" do
     login_page.completeLogin
-    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
     click_on("My Groups")
@@ -327,7 +327,7 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
 
   scenario "Visit Manage My Collections page" do
     login_page.completeLogin
-    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
     click_on("My Collections")
@@ -337,7 +337,7 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
 
   scenario "Visit Manage My Profile page" do
     login_page.completeLogin
-    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
     click_on("My Profile")
@@ -347,7 +347,7 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
 
   scenario "Visit Manage My Delegates page" do
     login_page.completeLogin
-    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
     click_on("My Delegates")
@@ -357,7 +357,7 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
 
   scenario "Visit Deposit New Article page" do
     login_page.completeLogin
-    logged_in_home_page= Curate::Pages::LoggedInHomePage.new
+    logged_in_home_page= Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
     click_on("New Article")
@@ -367,7 +367,7 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
 
   scenario "Visit Deposit New Dataset page" do
     login_page.completeLogin
-    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
     click_on("New Dataset")
@@ -377,7 +377,7 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
 
   scenario "Visit Deposit New Document page" do
     login_page.completeLogin
-    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
     click_on("New Document")
@@ -387,7 +387,7 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
 
   scenario "Visit Deposit New Image page" do
     login_page.completeLogin
-    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
     click_on("New Image")
@@ -397,7 +397,7 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
 
   scenario "Visit More Options page" do
     login_page.completeLogin
-    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
     click_on("More Options")
@@ -407,7 +407,7 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
 
   scenario "Visit Deposit New Audio page" do
     login_page.completeLogin
-    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
     click_on("More Options")
@@ -420,7 +420,7 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
 
   scenario "Visit Deposit New Senior Thesis page" do
     login_page.completeLogin
-    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
     click_on("More Options")
@@ -433,7 +433,7 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
 
   scenario "Log out" do
     login_page.completeLogin
-    logged_in_home_page = Curate::Pages::LoggedInHomePage.new
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
     click_on("Log Out")

--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -154,7 +154,7 @@ feature 'Facet Navigation', js: true do
 end
 
 feature 'Logged In User (Account details NOT updated) Browsing', js: true do
-  let(:login_page) {Curate::Pages::LoginPage.new(current_logger, account_details_updated: false)}
+  let(:login_page) { Curate::Pages::LoginPage.new(current_logger, account_details_updated: false) }
   scenario "Log in" do
     login_page.completeLogin
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
@@ -203,7 +203,7 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
 
   scenario "Visit Deposit New Article page" do
     login_page.completeLogin
-    logged_in_home_page= Curate::Pages::LoggedInHomePage.new(login_page)
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
     click_on("New Article")
@@ -282,7 +282,7 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
 end
 
 feature 'Logged In User (Account details updated) Browsing', js: true do
-  let(:login_page) {Curate::Pages::LoginPage.new(current_logger, account_details_updated: true)}
+  let(:login_page) { Curate::Pages::LoginPage.new(current_logger, account_details_updated: true) }
   scenario "Log in" do
     login_page.completeLogin
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
@@ -341,7 +341,7 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
 
   scenario "Visit Deposit New Article page" do
     login_page.completeLogin
-    logged_in_home_page= Curate::Pages::LoggedInHomePage.new(login_page)
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
     click_on("New Article")

--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -177,8 +177,8 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
     click_on("My Groups")
-    groups_page = Curate::Pages::MyGroupsPage.new
-    expect(groups_page).to be_on_page
+    account_details_page = Curate::Pages::AccountDetailsPage.new
+    expect(account_details_page).to be_on_page
   end
 
   scenario "Visit Manage My Collections page" do
@@ -187,8 +187,8 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
     click_on("My Collections")
-    collections_page = Curate::Pages::MyCollectionsPage.new
-    expect(collections_page).to be_on_page
+    account_details_page = Curate::Pages::AccountDetailsPage.new
+    expect(account_details_page).to be_on_page
   end
 
   scenario "Visit Manage My Profile page" do
@@ -197,8 +197,8 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
     click_on("My Profile")
-    profile_page = Curate::Pages::MyProfilePage.new
-    expect(profile_page).to be_on_page
+    account_details_page = Curate::Pages::AccountDetailsPage.new
+    expect(account_details_page).to be_on_page
   end
 
   scenario "Visit Deposit New Article page" do
@@ -207,8 +207,8 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
     click_on("New Article")
-    article_page = Curate::Pages::ArticlePage.new
-    expect(article_page).to be_on_page
+    account_details_page = Curate::Pages::AccountDetailsPage.new
+    expect(account_details_page).to be_on_page
   end
 
   scenario "Visit Deposit New Dataset page" do
@@ -217,8 +217,8 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
     click_on("New Dataset")
-    dataset_page = Curate::Pages::DatasetPage.new
-    expect(dataset_page).to be_on_page
+    account_details_page = Curate::Pages::AccountDetailsPage.new
+    expect(account_details_page).to be_on_page
   end
 
   scenario "Visit Deposit New Document page" do
@@ -227,8 +227,8 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
     click_on("New Document")
-    document_page = Curate::Pages::DocumentPage.new
-    expect(document_page).to be_on_page
+    account_details_page = Curate::Pages::AccountDetailsPage.new
+    expect(account_details_page).to be_on_page
   end
 
   scenario "Visit Deposit New Image page" do
@@ -237,8 +237,8 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
     click_on("New Image")
-    image_page = Curate::Pages::ImagePage.new
-    expect(image_page).to be_on_page
+    account_details_page = Curate::Pages::AccountDetailsPage.new
+    expect(account_details_page).to be_on_page
   end
 
   scenario "Visit More Options page" do
@@ -247,8 +247,8 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
     click_on("More Options")
-    options_page = Curate::Pages::StartDepositPage.new
-    expect(options_page).to be_on_page
+    account_details_page = Curate::Pages::AccountDetailsPage.new
+    expect(account_details_page).to be_on_page
   end
 
   scenario "Visit Deposit New Audio page" do
@@ -257,11 +257,8 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
     click_on("More Options")
-    options_page = Curate::Pages::StartDepositPage.new
-    expect(options_page).to be_on_page
-    find('.add-button.btn.btn-primary.add_new_audio').click
-    audio_page = Curate::Pages::AudioPage.new
-    expect(audio_page).to be_on_page
+    account_details_page = Curate::Pages::AccountDetailsPage.new
+    expect(account_details_page).to be_on_page
   end
 
   scenario "Visit Deposit New Senior Thesis page" do
@@ -270,11 +267,8 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
     click_on("More Options")
-    options_page = Curate::Pages::StartDepositPage.new
-    expect(options_page).to be_on_page
-    find('.add-button.btn.btn-primary.add_new_senior_thesis').click
-    thesis_page = Curate::Pages::ThesisPage.new
-    expect(thesis_page).to be_on_page
+    account_details_page = Curate::Pages::AccountDetailsPage.new
+    expect(account_details_page).to be_on_page
   end
 
   scenario "Log out" do

--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -154,7 +154,7 @@ feature 'Facet Navigation', js: true do
 end
 
 feature 'Logged In User (Account details NOT updated) Browsing', js: true do
-  let(:login_page) {Curate::Pages::LoginPage.new(current_logger, account_details_updated?: false)}
+  let(:login_page) {Curate::Pages::LoginPage.new(current_logger, account_details_updated: false)}
   scenario "Log in" do
     login_page.completeLogin
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
@@ -282,7 +282,7 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
 end
 
 feature 'Logged In User (Account details updated) Browsing', js: true do
-  let(:login_page) {Curate::Pages::LoginPage.new(current_logger, account_details_updated?: true)}
+  let(:login_page) {Curate::Pages::LoginPage.new(current_logger, account_details_updated: true)}
   scenario "Log in" do
     login_page.completeLogin
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)

--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -201,16 +201,6 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     expect(profile_page).to be_on_page
   end
 
-  scenario "Visit Manage My Delegates page" do
-    login_page.completeLogin
-    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
-    expect(logged_in_home_page).to be_on_page
-    logged_in_home_page.openActionsDrawer
-    click_on("My Delegates")
-    delegates_page = Curate::Pages::MyDelegatesPage.new
-    expect(delegates_page).to be_on_page
-  end
-
   scenario "Visit Deposit New Article page" do
     login_page.completeLogin
     logged_in_home_page= Curate::Pages::LoggedInHomePage.new(login_page)

--- a/spec/curate/pages/account_details_page.rb
+++ b/spec/curate/pages/account_details_page.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+module Curate
+  module Pages
+    class AccountDetailsPage
+      include Capybara::DSL
+      include CapybaraErrorIntel::DSL
+
+      def on_page?
+          on_valid_url? &&
+          status_response_ok? &&
+          valid_page_content?
+      end
+
+      def on_valid_url?
+        current_url == File.join(Capybara.app_host,'users/edit')
+      end
+
+      def status_response_ok?
+        status_code == 200
+      end
+
+      def valid_page_content?
+        has_content?("Account Details")
+        has_selector?(:link_or_button, "Update My Account")
+      end
+    end
+  end
+end

--- a/spec/curate/pages/account_details_page.rb
+++ b/spec/curate/pages/account_details_page.rb
@@ -6,13 +6,13 @@ module Curate
       include CapybaraErrorIntel::DSL
 
       def on_page?
-          on_valid_url? &&
+        on_valid_url? &&
           status_response_ok? &&
           valid_page_content?
       end
 
       def on_valid_url?
-        current_url == File.join(Capybara.app_host,'users/edit')
+        current_url == File.join(Capybara.app_host, 'users/edit')
       end
 
       def status_response_ok?

--- a/spec/curate/pages/loggedin_page.rb
+++ b/spec/curate/pages/loggedin_page.rb
@@ -1,6 +1,11 @@
+# frozen_string_literal: true
 module Curate
   module Pages
     class LoggedInHomePage < HomePage
+      def initialize(login_page={})
+        @login_page = login_page
+      end
+
       def on_page?
         super &&
         valid_logged_in_page_content? &&
@@ -20,8 +25,10 @@ module Curate
         has_content?("My Collections")
         has_content?("My Groups")
         has_content?("My Profile")
-        has_content?("My Delegates")
         has_content?("Log Out")
+        if @login_page.account_details_updated_flag == "true"
+          has_content?("My Delegates")
+        end
         find("div.btn-group.my-actions").click
       end
 

--- a/spec/curate/pages/loggedin_page.rb
+++ b/spec/curate/pages/loggedin_page.rb
@@ -2,20 +2,20 @@
 module Curate
   module Pages
     class LoggedInHomePage < HomePage
-      def initialize(login_page={})
+      def initialize(login_page = {})
         @login_page = login_page
       end
 
       def on_page?
         super &&
-        valid_logged_in_page_content? &&
-        manageDropdown? &&
-        depositDropdown?
+          valid_logged_in_page_content? &&
+          manageDropdown? &&
+          depositDropdown?
       end
 
       def valid_logged_in_page_content?
         find("div.btn-group.add-content") &&
-        find("div.btn-group.my-actions")
+          find("div.btn-group.my-actions")
       end
 
       def manageDropdown?

--- a/spec/curate/pages/login_page.rb
+++ b/spec/curate/pages/login_page.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'csv'
 require 'curate/curate_spec_helper'
 module Curate
@@ -11,17 +12,30 @@ module Curate
       attr_reader :current_logger
       attr_reader :account_details_updated_flag
 
-      def initialize(logger, account_details_updated_flag)
-        @account_details_updated_flag = account_details_updated_flag[:account_details_updated?].to_s
+      def initialize(logger, account_details_updated: false)
+        @account_details_updated = account_details_updated
         @current_logger = logger
         credentials = CSV.read(ENV['HOME']+"/test_data/QA/TestCredentials.csv")
-        # Filtering out items that satisfy the value of account_details_updated_flag
-        flagged_credentials = credentials.select{|entry| entry[3] == account_details_updated_flag[:account_details_updated?].to_s}
-        #randomly selecting a value from the remaining entries
+        # Filtering out items that satisfy the value of @account_details_updated
+        flagged_credentials = credentials.select{ |entry| cast_to_boolean(entry[3]) == @account_details_updated }
+        # randomly selecting a value from the remaining entries
         credentials_to_use = flagged_credentials.sample
         @userName = credentials_to_use[0]
         @passWord = credentials_to_use[1]
         @passCode = credentials_to_use[2]
+      end
+
+      def account_details_updated?
+        @account_details_updated
+      end
+
+      def cast_to_boolean(value)
+        case value
+        when /^[TY]/i, '1'
+          true
+        else
+          false
+        end
       end
 
       def completeLogin

--- a/spec/curate/pages/login_page.rb
+++ b/spec/curate/pages/login_page.rb
@@ -14,16 +14,14 @@ module Curate
       def initialize(logger, account_details_updated_flag)
         @account_details_updated_flag = account_details_updated_flag[:account_details_updated?].to_s
         @current_logger = logger
-        userNumber = Random.rand(1..5)
-        current_user = 0
-        CSV.foreach(ENV['HOME']+"/test_data/QA/TestCredentials.csv") do |row|
-          if current_user == userNumber
-            @userName = row[0]
-            @passWord = row[1]
-            @passCode = row[2]
-          end
-          current_user = current_user+1
-        end
+        credentials = CSV.read(ENV['HOME']+"/test_data/QA/TestCredentials.csv")
+        # Filtering out items that satisfy the value of account_details_updated_flag
+        flagged_credentials = credentials.select{|entry| entry[3] == account_details_updated_flag[:account_details_updated?].to_s}
+        #randomly selecting a value from the remaining entries
+        credentials_to_use = flagged_credentials.sample
+        @userName = credentials_to_use[0]
+        @passWord = credentials_to_use[1]
+        @passCode = credentials_to_use[2]
       end
 
       def completeLogin

--- a/spec/curate/pages/login_page.rb
+++ b/spec/curate/pages/login_page.rb
@@ -1,7 +1,6 @@
 require 'csv'
 require 'curate/curate_spec_helper'
 module Curate
-
   module Pages
     class LoginPage
       include Capybara::DSL
@@ -10,8 +9,10 @@ module Curate
       attr_reader :passWord
       attr_reader :passCode
       attr_reader :current_logger
+      attr_reader :account_details_updated_flag
 
-      def initialize(logger)
+      def initialize(logger, account_details_updated_flag)
+        @account_details_updated_flag = account_details_updated_flag[:account_details_updated?].to_s
         @current_logger = logger
         userNumber = Random.rand(1..5)
         current_user = 0


### PR DESCRIPTION
This work originated from [failing scenarios](https://jira.library.nd.edu/browse/DLTP-939) against curate prod. I wrote some additional scenarios to fulfill the test coverage gap after addressing test failures. 

In this PR:
* Add scenarios for both type of users: with and without account details updated
* Identify user accounts based on flag in TestCredentials.csv
* Change in random user selection from TestCredentials.csv
* Address failure due to 'My delegates' button not visible for accounts without an updated profile in curate
* Handle scenarios for users without account details updated by validating against 'Account registration page'