### PR TITLE
Removing webkit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ group :testcontroller do
   gem 'logging'
   gem 'byebug'
   gem 'selenium-webdriver'
-  gem 'capybara-webkit'
   gem 'swagger-core'
   gem 'aws-sdk'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,9 +40,6 @@ GEM
     capybara-screenshot (1.0.14)
       capybara (>= 1.0, < 3)
       launchy
-    capybara-webkit (1.12.0)
-      capybara (>= 2.3.0, < 2.13.0)
-      json
     capybara_error_intel (1.0.2)
       capybara (~> 2)
       rspec (>= 2.1, < 4.x)
@@ -55,7 +52,6 @@ GEM
     hashie (3.3.2)
     i18n (0.7.0)
     jmespath (1.3.1)
-    json (1.8.6)
     json-schema (2.7.0)
       addressable (>= 2.4)
     launchy (2.4.3)
@@ -143,7 +139,6 @@ DEPENDENCIES
   capistrano-bundler
   capybara
   capybara-screenshot
-  capybara-webkit
   capybara_error_intel
   logging
   poltergeist
@@ -155,4 +150,4 @@ DEPENDENCIES
   swagger-core
 
 BUNDLED WITH
-   1.14.3
+   1.14.6

--- a/README.md
+++ b/README.md
@@ -40,24 +40,6 @@ eval "$(phantomenv init -)"
 ```
 To setup through Boxen uses https://github.com/boxen/puppet-phantomjs to set up phantom JS which is a wrapper around https://github.com/boxen/phantomenv
 
-## Install/Upgrade qt5 on local:
-For sites using Reactjs we will use the webkit driver. capybara-webkit depends on a WebKit implementation from Qt, a cross-platform development toolkit.
-
-Lookup the command specific to your OS: https://github.com/thoughtbot/capybara-webkit/wiki/Installing-Qt-and-compiling-capybara-webkit#homebrew
-
-Example for macOS Sierra:
-``` console
-brew install qt5 --with-qtwebkit
-brew link --force qt5
-gem uninstall --all capybara-webkit
-gem install capybara-webkit
-which qmake; qmake --version
-# Expected output:
-# /usr/local/bin/qmake
-# QMake version 3.0
-# Using Qt version 5.x in /usr/local/Cellar/qt5/5.x/lib
-```
-
 ## Setting up shared drive
 These tests will need to access a shared drive that has test data
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,6 @@ require 'capybara_error_intel/dsl'
 require 'capybara-screenshot/rspec'
 require 'logging'
 require 'rspec/logging_helper'
-require 'capybara-webkit'
 require 'swagger'
 require 'open-uri'
 
@@ -17,11 +16,6 @@ require 'open-uri'
 Dir.glob(File.expand_path('../spec_support/**/*.rb', __FILE__)).each { |filename| require filename }
 
 Capybara.run_server = false
-
-Capybara::Webkit.configure do |config|
-  config.allow_unknown_urls
-  config.skip_image_loading
-end
 
 # Keep only the screenshots generated from the last failing test suite
 Capybara::Screenshot.prune_strategy = :keep_last_run

--- a/spec/spec_support/example_logging.rb
+++ b/spec/spec_support/example_logging.rb
@@ -177,8 +177,10 @@ module ExampleLogging
 
     private
 
+      # Enforce a driver to specific applications here
+      # Example: 'dave' => :poltergeist
       CAPYBARA_DRIVER_MAP = {
-        'dave' => :webkit
+
       }.freeze
 
       DEFAULT_CAPYBARA_DRIVER = :poltergeist


### PR DESCRIPTION
We've found out that the poltergeist driver works well for ReactJS
applications as well.
I'm taking this out of the testing framework to simplify
workstation setup time for other developers. QT5 setup is very cumbersome for MacOS.