### PR TITLE
Pretty printing JSON output for better readability

### DIFF
--- a/spec/spec_support/json_output_formatter.rb
+++ b/spec/spec_support/json_output_formatter.rb
@@ -9,8 +9,8 @@ class JsonOutputFormatter < RSpec::Core::Formatters::JsonFormatter
   RSpec::Core::Formatters.register self
 
   def close(notification)
-    super
     @output_hash[:runID] ||= "#{RunIdentifier.get}"
+    output.write JSON.pretty_generate(@output_hash)
     report_json_result
   end
 


### PR DESCRIPTION
The 'close' method of parent class simply spits out the entire JSON
output which is very hard to read. I'm removing 'super' and explicitly
using JSON.pretty_generate instead.