### PR TITLE
Updates scenario "modal facets"

### DIFF
--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -129,8 +129,9 @@ feature 'Facet Navigation', js: true do
     click_on('Search')
     ['Department or Unit', 'Collection'].shuffle.each do |facet_name|
       current_logger.info(context: "Processing Facet: #{facet_name}")
-      expect(page).not_to have_selector("#ajax-modal")
+      expect(page).not_to have_selector("#ajax-modal", visible: true)
       click_on(facet_name)
+      sleep(3)
       expect(page).to have_selector('#ajax-modal', visible: true)
       expect(page).to have_content(facet_name)
       within('#ajax-modal') do


### PR DESCRIPTION
The change on line 132 makes it so the test expect the page not to have
any visible ajax modals instead of expect no ajax modals. Without this,
test fails after the first modal tested is closed because it is still
on the page but not visible.  The change on line 134 is necessary
because the otherwise it tests for the opened ajax modal to be visible
before pprd opens the ajax modal.