### PR TITLE
Mh gatekeeper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :testcontroller do
   gem 'logging'
   gem 'byebug'
   gem 'selenium-webdriver'
-  gem 'swagger-core'
+  gem 'swagger-parser'
   gem 'aws-sdk'
   gem 'airborne'
 end

--- a/spec/gatekeeper/gatekeeper_config.yml
+++ b/spec/gatekeeper/gatekeeper_config.yml
@@ -1,0 +1,3 @@
+dev: https://fec9x3dsdg.execute-api.us-east-1.amazonaws.com/
+pprd: jello
+prod: jello

--- a/spec/gatekeeper/gatekeeper_repo_config.yml
+++ b/spec/gatekeeper/gatekeeper_repo_config.yml
@@ -1,0 +1,1 @@
+repo_url: https://github.com/ndlib/gatekeeper

--- a/spec/gatekeeper/gatekeeper_spec_helper.rb
+++ b/spec/gatekeeper/gatekeeper_spec_helper.rb
@@ -1,2 +1,2 @@
-#frozen_string_literal: true
+# frozen_string_literal: true
 require 'spec_helper'

--- a/spec/gatekeeper/gatekeeper_spec_helper.rb
+++ b/spec/gatekeeper/gatekeeper_spec_helper.rb
@@ -1,0 +1,2 @@
+#frozen_string_literal: true
+require 'spec_helper'

--- a/spec/gatekeeper/integration/int_gatekeeper_spec.rb
+++ b/spec/gatekeeper/integration/int_gatekeeper_spec.rb
@@ -1,11 +1,11 @@
-#frozen_string_literal: true
+# frozen_string_literal: true
 require 'gatekeeper/gatekeeper_spec_helper'
 
 feature 'Gatekeeper API test' do
   SwaggerHandler.operations(for_file_path: __FILE__).each do |operation|
     scenario "calls #{operation.verb} #{operation.path}" do
-      request['authorization'] = "Token token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJkYXRhIjp7Im5ldGlkIjoidF9oZXNsaWIwMSJ9fQ.6MDSyPVHwx7ZFtsY6fQww4rj6shLHiqtmMXOCLrD89s"
-      result = public_send(operation.verb, operation.url)
+      schema = RequestBuilder.new(operation)
+      result = schema.send_security_vs_none
       current_response = ResponseValidator.new(operation, result)
       expect(current_response).to be_valid_response
     end

--- a/spec/gatekeeper/integration/int_gatekeeper_spec.rb
+++ b/spec/gatekeeper/integration/int_gatekeeper_spec.rb
@@ -1,0 +1,13 @@
+#frozen_string_literal: true
+require 'gatekeeper/gatekeeper_spec_helper'
+
+feature 'Gatekeeper API test' do
+  SwaggerHandler.operations(for_file_path: __FILE__).each do |operation|
+    scenario "calls #{operation.verb} #{operation.path}" do
+      request['authorization'] = "Token token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJkYXRhIjp7Im5ldGlkIjoidF9oZXNsaWIwMSJ9fQ.6MDSyPVHwx7ZFtsY6fQww4rj6shLHiqtmMXOCLrD89s"
+      result = public_send(operation.verb, operation.url)
+      current_response = ResponseValidator.new(operation, result)
+      expect(current_response).to be_valid_response
+    end
+  end
+end

--- a/spec/spec_support/request_builder.rb
+++ b/spec/spec_support/request_builder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-#This class provides a mechanism for adding header fields in a request
-#like authorization headers.
+# This class provides a mechanism for adding header fields in a request
+# like authorization headers.
 
 class RequestBuilder
   def initialize(operation)
@@ -13,7 +13,7 @@ class RequestBuilder
     schema = @current_operation.responses.values[0].schema.root
     if schema.keys.include?('securityDefinitions')
       # Get the type, name, and in fields of the security
-      schema_security=schema.securityDefinitions.values[0]
+      schema_security = schema.securityDefinitions.values[0]
       # Gets the name of the security to use for authorization
       name = schema_security.name
       user_home_dir = File.expand_path('~')

--- a/spec/spec_support/request_builder.rb
+++ b/spec/spec_support/request_builder.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+#This class provides a mechanism for adding header fields in a request
+#like authorization headers.
+
+class RequestBuilder
+  def initialize(operation)
+    @current_operation = operation
+  end
+
+  # Identifies if the API has security or not then sends request accordingly
+  def send_security_vs_none
+    # Get schema of the response
+    schema = @current_operation.responses.values[0].schema.root
+    if schema.keys.include?('securityDefinitions')
+      # Get the type, name, and in fields of the security
+      schema_security=schema.securityDefinitions.values[0]
+      # Gets the name of the security to use for authorization
+      name = schema_security.name
+      user_home_dir = File.expand_path('~')
+      # Accesses the file to get the jwt token
+      yaml = YAML.load_file(File.join("#{user_home_dir}", 'test_data/QA/jwt_token.yml'))
+      token = yaml.fetch('token')
+      # Uses the name and token variables bypass security
+      RestClient.public_send(@current_operation.verb, @current_operation.url, "#{name}": "#{token}")
+    else
+      RestClient.public_send(@current_operation.verb, @current_operation.url)
+    end
+  end
+end

--- a/spec/spec_support/response_validator.rb
+++ b/spec/spec_support/response_validator.rb
@@ -20,14 +20,16 @@ class ResponseValidator
     ## Snippet below is a workaround to the resolve_refs method.
     # Get the schema for key[0]
     response_schema = @current_operation.responses.values[0]
+    # Gets the response $ref
+    key_ref = response_schema.schema.values[0]
+    # Seperates the $ref from path format to get specific $ref
+    ref=key_ref.split('#/definitions/').join
     # Resolve definition references
     resolved_schema = response_schema.schema.root.definitions
     # Resolve definition properties
-    schema_properties = resolved_schema.values[0].properties.keys
-
+    schema_properties = resolved_schema.fetch("#{ref}").properties.keys
     # Parse result body as JSON and find the keys
     result_keys = JSON.parse(@current_result.body).keys
-
     # Making sure all the properties listed in Swagger definition
     # are present in the result body
     (schema_properties & result_keys).sort == schema_properties.sort


### PR DESCRIPTION
Creates the gatekeeper file under the spec folder. 
Updates Gemfile to use swagger-parser instead of swagger-core because swagger core has issues with identifying the security type for API.
Creates the repo_config, config, and spec_helper files for gatekeeper.
Creates a new class RequestBuilder under the spec_support folder use for sending requests to APIs
that have or do not have security.
Creates int_gatekeeper_spec.rb API test.
