### PR TITLE
Mh refactor sleep

### DIFF
--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -131,7 +131,6 @@ feature 'Facet Navigation', js: true do
       current_logger.info(context: "Processing Facet: #{facet_name}")
       expect(page).not_to have_selector("#ajax-modal", visible: true)
       click_on(facet_name)
-      sleep(3)
       expect(page).to have_selector('#ajax-modal', visible: true)
       expect(page).to have_content(facet_name)
       within('#ajax-modal') do
@@ -145,7 +144,6 @@ feature 'Facet Navigation', js: true do
     visit '/'
     click_on('Search')
     ['Type_of_Work', 'Creator', 'Subject', 'Language', 'Publisher', 'Academic_Status'].shuffle.each do |facet_name|
-      sleep(0.3) # Included because the JS expand behavior was not always completing before the driver said it was ready
       current_logger.info(context: "Processing Facet: #{facet_name}")
       expect(page).not_to have_css("ul.facets #collapse_#{facet_name}.in")
       find("ul.facets a[data-target=\"#collapse_#{facet_name}\"]").click

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,8 @@ RSpec.configure do |config|
   config.include RSpec::LoggingHelper
   config.include ExampleLogging
   config.include ExampleLogging::CapybaraInjection
+  config.include SleepInjector
+
   config.capture_log_messages
   # Ensuring that things run in a random order; This is a prefered mechanism
   # as it helps identify temporal couplings

--- a/spec/spec_support/sleep_injector.rb
+++ b/spec/spec_support/sleep_injector.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal
+# frozen_string_literal = true
 require 'capybara/node/actions'
 require 'capybara/dsl'
 # This class adds a sleep statement at the end of the click_on class for
@@ -6,9 +6,9 @@ require 'capybara/dsl'
 module SleepInjector
   include Capybara::Node::Actions
   include Capybara::DSL
-  def click_link_or_button(locator=nil, options={})
+  def click_link_or_button(locator = nil, options = {})
     super
     sleep(2)
   end
-  alias_method :click_on, :click_link_or_button
+  alias click_on click_link_or_button
 end

--- a/spec/spec_support/sleep_injector.rb
+++ b/spec/spec_support/sleep_injector.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal
+require 'capybara/node/actions'
+require 'capybara/dsl'
+# This class adds a sleep statement at the end of the click_on class for
+
+module SleepInjector
+  include Capybara::Node::Actions
+  include Capybara::DSL
+  def click_link_or_button(locator=nil, options={})
+    super
+    sleep(2)
+  end
+  alias_method :click_on, :click_link_or_button
+end


### PR DESCRIPTION
Creates a the SleepInjector module which adds a 2 second sleep statement to the end of Capybara click_on method.  This will aid in removing sleep statements from test code as the statements are often necessary after using click_on to ensure the action has occurred.  Also, this module is included into the spec_helper so it can be used by all tests.  The func_curate_spec.rb was used to test this module and sleep statements have been removed from it.