### PR TITLE
Mh sleep refactor

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,6 @@ RSpec.configure do |config|
   config.include RSpec::LoggingHelper
   config.include ExampleLogging
   config.include ExampleLogging::CapybaraInjection
-  config.include SleepInjector
 
   config.capture_log_messages
   # Ensuring that things run in a random order; This is a prefered mechanism

--- a/spec/spec_support/sleep_injector.rb
+++ b/spec/spec_support/sleep_injector.rb
@@ -1,14 +1,21 @@
 # frozen_string_literal = true
-require 'capybara/node/actions'
-require 'capybara/dsl'
+require 'capybara/node/element'
 # This class adds a sleep statement at the end of the click_on class for
 
 module SleepInjector
-  include Capybara::Node::Actions
-  include Capybara::DSL
-  def click_link_or_button(locator = nil, options = {})
-    super
-    sleep(2)
+  class Capybara::Node::Element
+    # Method wrapping for the .click method to add sleep statement
+    old_click = instance_method(:click)
+    define_method(:click) do
+      old_click.bind(self).()
+      sleep(2)
+    end
+
+    # Method wrapping for the .trigger(event) method to add sleep statement
+    old_trigger = instance_method(:trigger)
+    define_method(:trigger) do |event|
+      old_trigger.bind(self).(event)
+      sleep(3)
+    end
   end
-  alias click_on click_link_or_button
 end

--- a/spec/spec_support/sleep_injector.rb
+++ b/spec/spec_support/sleep_injector.rb
@@ -1,21 +1,19 @@
-# frozen_string_literal = true
+# frozen_string_literal: true
 require 'capybara/node/element'
 # This class adds a sleep statement at the end of the click_on class for
 
-module SleepInjector
-  class Capybara::Node::Element
-    # Method wrapping for the .click method to add sleep statement
-    old_click = instance_method(:click)
-    define_method(:click) do
-      old_click.bind(self).()
-      sleep(2)
-    end
+class Capybara::Node::Element
+  # Method wrapping for the .click method to add sleep statement
+  old_click = instance_method(:click)
+  define_method(:click) do
+    old_click.bind(self).call
+    sleep(2)
+  end
 
-    # Method wrapping for the .trigger(event) method to add sleep statement
-    old_trigger = instance_method(:trigger)
-    define_method(:trigger) do |event|
-      old_trigger.bind(self).(event)
-      sleep(3)
-    end
+  # Method wrapping for the .trigger(event) method to add sleep statement
+  old_trigger = instance_method(:trigger)
+  define_method(:trigger) do |event|
+    old_trigger.bind(self).call(event)
+    sleep(3)
   end
 end


### PR DESCRIPTION
Changes the sleep_injector.rb file to remove the module format as a class format is simpler. Also, gets rid of overriding the click_on  method since it calls .click so by overriding the .click method, the sleep statement is passed to the click_on method.  Uses method wrapping to override the .click and .trigger methods to add sleep statements.