### PR TITLE
Updates RequestBuilder to avoid "options" UI verb

### DIFF
--- a/spec/spec_support/request_builder.rb
+++ b/spec/spec_support/request_builder.rb
@@ -9,7 +9,7 @@ class RequestBuilder
 
   # Identifies if the API has security or not then sends request accordingly
   def send_security_vs_none
-    if @current_operation.verb.to_s != "options"
+    if meaningful_method_name?
       # Get schema of the response
       schema = @current_operation.responses.values[0].schema.root
       if schema.keys.include?('securityDefinitions')
@@ -27,5 +27,9 @@ class RequestBuilder
         RestClient.public_send(@current_operation.verb, @current_operation.url)
       end
     end
+  end
+
+  def meaningful_method_name?
+    @current_operation.verb.to_s != "options"
   end
 end

--- a/spec/spec_support/request_builder.rb
+++ b/spec/spec_support/request_builder.rb
@@ -9,21 +9,23 @@ class RequestBuilder
 
   # Identifies if the API has security or not then sends request accordingly
   def send_security_vs_none
-    # Get schema of the response
-    schema = @current_operation.responses.values[0].schema.root
-    if schema.keys.include?('securityDefinitions')
-      # Get the type, name, and in fields of the security
-      schema_security = schema.securityDefinitions.values[0]
-      # Gets the name of the security to use for authorization
-      name = schema_security.name
-      user_home_dir = File.expand_path('~')
-      # Accesses the file to get the jwt token
-      yaml = YAML.load_file(File.join("#{user_home_dir}", 'test_data/QA/jwt_token.yml'))
-      token = yaml.fetch('token')
-      # Uses the name and token variables bypass security
-      RestClient.public_send(@current_operation.verb, @current_operation.url, "#{name}": "#{token}")
-    else
-      RestClient.public_send(@current_operation.verb, @current_operation.url)
+    if @current_operation.verb.to_s != "options"
+      # Get schema of the response
+      schema = @current_operation.responses.values[0].schema.root
+      if schema.keys.include?('securityDefinitions')
+        # Get the type, name, and in fields of the security
+        schema_security = schema.securityDefinitions.values[0]
+        # Gets the name of the security to use for authorization
+        name = schema_security.name
+        user_home_dir = File.expand_path('~')
+        # Accesses the file to get the jwt token
+        yaml = YAML.load_file(File.join("#{user_home_dir}", 'test_data/QA/jwt_token.yml'))
+        token = yaml.fetch('token')
+        # Uses the name and token variables bypass security
+        RestClient.public_send(@current_operation.verb, @current_operation.url, "#{name}": "#{token}")
+      else
+        RestClient.public_send(@current_operation.verb, @current_operation.url)
+      end
     end
   end
 end

--- a/spec/spec_support/request_builder.rb
+++ b/spec/spec_support/request_builder.rb
@@ -9,7 +9,7 @@ class RequestBuilder
 
   # Identifies if the API has security or not then sends request accordingly
   def send_security_vs_none
-    if meaningful_method_name?
+    if not_option?
       # Get schema of the response
       schema = @current_operation.responses.values[0].schema.root
       if schema.keys.include?('securityDefinitions')
@@ -29,7 +29,7 @@ class RequestBuilder
     end
   end
 
-  def meaningful_method_name?
+  def not_option?
     @current_operation.verb.to_s != "options"
   end
 end


### PR DESCRIPTION
As we do not want to send a request for the "options" verb,
send_security_vs_none now has an outer if statement so that a
pubic_send will only be used for operation verbs other than "options"