### PR TITLE
Hp input url

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,6 +45,7 @@ RSpec.configure do |config|
   config.before(:example) do |rspec_example|
     @current_logger = ExampleLogging.start(example: rspec_example, config: ENV, test_handler: self)
     ExampleLogging.current_logger = @current_logger
+    InitializeExample.initialize_app_host(example: rspec_example, config: ENV)
   end
 
   config.after(:example) do |_|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,7 +38,7 @@ RSpec.configure do |config|
   config.before(:suite) do
     RunIdentifier.set
     CloudwatchEventHandler.set_aws_config
-    new_save_path = RunIdentifier.get_screenshots_save_path
+    new_save_path = ScreenshotsManager.get_screenshots_save_path
     Capybara.save_path = new_save_path
   end
 

--- a/spec/spec_support/example_logging.rb
+++ b/spec/spec_support/example_logging.rb
@@ -114,7 +114,6 @@ module ExampleLogging
     #   @return [String]
     def_delegator :example_variable, :application_name_under_test
 
-
     # Used to configure the specifics of this application
     # @example ENV
     # @return [Hash]

--- a/spec/spec_support/example_logging.rb
+++ b/spec/spec_support/example_logging.rb
@@ -153,7 +153,6 @@ module ExampleLogging
       @environment_under_test = config.fetch('ENVIRONMENT', DEFAULT_ENVIRONMENT)
       @path_to_spec_directory = File.expand_path('../../', __FILE__)
       initialize_example_variables!
-      initialize_app_host!
       @current_logger = Logging.logger[application_name_under_test]
       initialize_capybara_drivers!
     end
@@ -299,14 +298,7 @@ module ExampleLogging
       end
 
       def initialize_example_variables!
-        @example_variable = ExampleVariableExtractor.call(path: @example.metadata.fetch(:absolute_file_path))
-      end
-
-      def initialize_app_host!
-        servers_by_environment = YAML.load_file(
-          File.expand_path("./#{application_name_under_test}/#{application_name_under_test}_config.yml", path_to_spec_directory)
-        )
-        Capybara.app_host = servers_by_environment.fetch(environment_under_test)
+        @example_variable = ExampleVariableExtractor.call(path: @example.metadata.fetch(:absolute_file_path), config: config)
       end
   end
   private_constant :ExampleWrapperWithLogging

--- a/spec/spec_support/example_variable_extractor.rb
+++ b/spec/spec_support/example_variable_extractor.rb
@@ -1,14 +1,15 @@
-ExampleVariable = Struct.new(:application_name_under_test, :test_type)
+ExampleVariable = Struct.new(:application_name_under_test, :test_type, :path_to_spec_directory, :environment_under_test)
 
 module ExampleVariableExtractor
   # @param path [String] The path to the spec file that is being tested
   # @return [ExampleStruct] An object that responds to #application_name_under_test and #test_type
   # @note If we start nesting our specs, this may need to be revisited.
-  def self.call(path:)
+  def self.call(path:, config:)
     path_to_spec_directory = File.expand_path('../../', __FILE__)
     spec_sub_directory = path.sub("#{path_to_spec_directory}/", '').split('/')
     application_name_under_test = spec_sub_directory[0]
     test_type = spec_sub_directory[1]
-    ExampleVariable.new(application_name_under_test, test_type)
+    environment_under_test = config.fetch('ENVIRONMENT', ExampleLogging::DEFAULT_ENVIRONMENT)
+    ExampleVariable.new(application_name_under_test, test_type, path_to_spec_directory, environment_under_test)
   end
 end

--- a/spec/spec_support/test_runtime.rb
+++ b/spec/spec_support/test_runtime.rb
@@ -26,7 +26,7 @@ module ScreenshotsManager
     Dir.chdir(screenshots_root)
     screenshots_directories = Dir.glob('*').select { |f| File.directory? f } # Returns a list of all screenshots directories in screenshots_root
     screenshots_directories.reverse.each_with_index { |dir, index|
-      if index>=runs
+      if index >= runs
         FileUtils.rm_rf(dir)
       end
     }
@@ -39,6 +39,8 @@ module ScreenshotsManager
 end
 
 module InitializeExample
+  # * Checks if value of ENVIRONMENT is a URL or key
+  # * Sets Capybara.app_host to a URL
   def self.initialize_app_host(example:, config:)
     @example = example
     @config = config

--- a/spec/spec_support/test_runtime.rb
+++ b/spec/spec_support/test_runtime.rb
@@ -37,3 +37,30 @@ module ScreenshotsManager
     File.join(screenshots_root, RunIdentifier.get)
   end
 end
+
+module InitializeExample
+  def self.initialize_app_host(example:, config:)
+    @example = example
+    @config = config
+    initialize_example_variables!
+    if valid_url?(@example_variable.environment_under_test)
+      Capybara.app_host = @example_variable.environment_under_test
+    else
+      servers_by_environment = YAML.load_file(
+        File.expand_path("./#{@example_variable.application_name_under_test}/#{@example_variable.application_name_under_test}_config.yml", @example_variable.path_to_spec_directory)
+      )
+      Capybara.app_host = servers_by_environment.fetch(@example_variable.environment_under_test)
+    end
+  end
+
+  def self.initialize_example_variables!
+    @example_variable = ExampleVariableExtractor.call(path: @example.metadata.fetch(:absolute_file_path), config: @config)
+  end
+
+  def self.valid_url?(url)
+    uri = URI.parse(url)
+    uri.is_a?(URI::HTTP) && !uri.host.nil?
+  rescue URI::InvalidURIError
+    false
+  end
+end

--- a/spec/spec_support/test_runtime.rb
+++ b/spec/spec_support/test_runtime.rb
@@ -2,6 +2,8 @@
 require 'fileutils'
 
 module RunIdentifier
+  # * Provides getter and setter methods to
+  # create a unique ID for identifying the test run
   def self.set
     @run_identifier = DateTime.now.strftime("%Y-%m-%dT%H:%M:%S.%L-05:00")
   end

--- a/spec/spec_support/test_runtime.rb
+++ b/spec/spec_support/test_runtime.rb
@@ -9,7 +9,9 @@ module RunIdentifier
   def self.get
     @run_identifier
   end
+end
 
+module ScreenshotsManager
   # * Create tmp/screenshots dir if not present
   # * Remove directories older than value specified in argument
   # * returns a relative path of the directory to which current test should save screenshots
@@ -28,8 +30,8 @@ module RunIdentifier
     }
 
     # Using value of @run_identifier as directory name
-    FileUtils.mkdir self.get
+    FileUtils.mkdir RunIdentifier.get
     Dir.chdir(current_working_directory) # Return to current directory so screenshots are in the right place
-    File.join(screenshots_root, self.get)
+    File.join(screenshots_root, RunIdentifier.get)
   end
 end


### PR DESCRIPTION
In AWS code build/deploy, new environment URLs are not static and are built on-the-fly. Currently, our QA framework restricts testing against only those endpoints that are listed in spec/appName/appName_config.yml. This pull request allows us to pass a URL as target environment for testing an application/endpoint which will simplify continuous integration of QA testing with AWS.

In this PR I am also refactoring some previous code to simplify module behavior and intent. 

* Refactoring test_runtime.rb to separate modules
* Creates a new module InitializeExample to set Capybara.app_host based on value of ENVIRONMENT