### PR TITLE
Updating Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
       domain_name (~> 0.5)
     i18n (0.7.0)
     jmespath (1.3.1)
-    json-schema (2.7.0)
+    json-schema (2.8.0)
       addressable (>= 2.4)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -127,7 +127,7 @@ GEM
     sshkit (1.11.5)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    swagger-core (0.2.3)
+    swagger-parser (0.2.6)
       addressable (~> 2.3)
       hashie (~> 3.0, < 3.4.0)
       json-schema (~> 2.2)
@@ -166,7 +166,7 @@ DEPENDENCIES
   rubocop
   rubocop-rspec
   selenium-webdriver
-  swagger-core
+  swagger-parser
 
 BUNDLED WITH
    1.14.6


### PR DESCRIPTION
It seems like we didn't run 'bundle install' before pushing the code
change for switching from swagger-core to swagger-parser gem in
https://github.com/ndlib/QA_tests/pull/114