### PR TITLE
Refactoring code

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,6 +46,7 @@ RSpec.configure do |config|
     @current_logger = ExampleLogging.start(example: rspec_example, config: ENV, test_handler: self)
     ExampleLogging.current_logger = @current_logger
     InitializeExample.initialize_app_host(example: rspec_example, config: ENV)
+    InitializeExample.initialize_capybara_drivers!
   end
 
   config.after(:example) do |rspec_example|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,7 +48,8 @@ RSpec.configure do |config|
     InitializeExample.initialize_app_host(example: rspec_example, config: ENV)
   end
 
-  config.after(:example) do |_|
+  config.after(:example) do |rspec_example|
+    ErrorReporter.conditionally_report_unsuccessful_scenario(example: rspec_example)
     @current_logger.stop(driver: Capybara.current_session.driver)
     ExampleLogging.reset_current_logger!
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,6 +51,7 @@ RSpec.configure do |config|
 
   config.after(:example) do |rspec_example|
     ErrorReporter.conditionally_report_unsuccessful_scenario(example: rspec_example)
+    VerifyNetworkTraffic.report_network_traffic(driver: Capybara.current_session.driver, test_handler: self)
     @current_logger.stop(driver: Capybara.current_session.driver)
     ExampleLogging.reset_current_logger!
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,7 +52,7 @@ RSpec.configure do |config|
   config.after(:example) do |rspec_example|
     ErrorReporter.conditionally_report_unsuccessful_scenario(example: rspec_example)
     VerifyNetworkTraffic.report_network_traffic(driver: Capybara.current_session.driver, test_handler: self)
-    @current_logger.stop(driver: Capybara.current_session.driver)
+    @current_logger.stop()
     ExampleLogging.reset_current_logger!
   end
 end

--- a/spec/spec_support/example_logging.rb
+++ b/spec/spec_support/example_logging.rb
@@ -153,7 +153,6 @@ module ExampleLogging
       @path_to_spec_directory = File.expand_path('../../', __FILE__)
       initialize_example_variables!
       @current_logger = Logging.logger[application_name_under_test]
-      initialize_capybara_drivers!
     end
 
     # Responsible for logging the start of a test
@@ -173,21 +172,6 @@ module ExampleLogging
     end
 
     private
-
-      # Enforce a driver to specific applications here
-      # Example: 'dave' => :poltergeist
-      CAPYBARA_DRIVER_MAP = {
-
-      }.freeze
-
-      DEFAULT_CAPYBARA_DRIVER = :poltergeist
-
-      def initialize_capybara_drivers!
-        @capybara_driver_name = CAPYBARA_DRIVER_MAP.fetch(application_name_under_test, :poltergeist)
-        Capybara.current_driver = @capybara_driver_name
-        Capybara.javascript_driver = @capybara_driver_name
-      end
-
       def report_network_traffic(driver:)
         return true unless driver_allows_network_traffic_verification?
         return true if ENV.fetch('SKIP_VERIFY_NETWORK_TRAFFIC', false)

--- a/spec/spec_support/example_logging.rb
+++ b/spec/spec_support/example_logging.rb
@@ -167,7 +167,6 @@ module ExampleLogging
     # @param driver [#network_traffic]
     # @return [ExampleLogging::ExampleWrapper]
     def stop(driver:)
-      conditionally_report_unsuccessful_scenario
       report_network_traffic(driver: driver)
       report_end_of_example
       self
@@ -187,17 +186,6 @@ module ExampleLogging
         @capybara_driver_name = CAPYBARA_DRIVER_MAP.fetch(application_name_under_test, :poltergeist)
         Capybara.current_driver = @capybara_driver_name
         Capybara.javascript_driver = @capybara_driver_name
-      end
-
-      def conditionally_report_unsuccessful_scenario
-        return true if successful_scenario?
-        # Leverage RSpec's logic to zero in on the location of failure from the exception backtrace
-        location_of_failure = RSpec.configuration.backtrace_formatter.format_backtrace(example.exception.backtrace).first
-        error(context: "FAILED example", location_of_failure: location_of_failure, message: example.exception.message)
-      end
-
-      def successful_scenario?
-        example.exception.nil?
       end
 
       def report_network_traffic(driver:)

--- a/spec/spec_support/example_logging.rb
+++ b/spec/spec_support/example_logging.rb
@@ -163,18 +163,10 @@ module ExampleLogging
     end
 
     # Responsible for consistent logging of the end steps of a test
-    # @param driver [#network_traffic]
     # @return [ExampleLogging::ExampleWrapper]
     def stop
-      report_end_of_example
-      self
+      info(context: "END example", example: example.full_description, location: example.location)
     end
-
-    private
-
-      def report_end_of_example
-        info(context: "END example", example: example.full_description, location: example.location)
-      end
 
     public
 

--- a/spec/spec_support/example_logging.rb
+++ b/spec/spec_support/example_logging.rb
@@ -165,12 +165,13 @@ module ExampleLogging
     # Responsible for consistent logging of the end steps of a test
     # @param driver [#network_traffic]
     # @return [ExampleLogging::ExampleWrapper]
-    def stop(driver:)
+    def stop
       report_end_of_example
       self
     end
 
     private
+
       def report_end_of_example
         info(context: "END example", example: example.full_description, location: example.location)
       end

--- a/spec/spec_support/test_runtime.rb
+++ b/spec/spec_support/test_runtime.rb
@@ -41,6 +41,7 @@ end
 module InitializeExample
   # * Checks if value of ENVIRONMENT is a URL or key
   # * Sets Capybara.app_host to a URL
+  # * Sets Capybara driver name
   def self.initialize_app_host(example:, config:)
     @example = example
     @config = config
@@ -64,6 +65,20 @@ module InitializeExample
     uri.is_a?(URI::HTTP) && !uri.host.nil?
   rescue URI::InvalidURIError
     false
+  end
+
+  # Enforce a driver to specific applications here
+  # Example: 'dave' => :poltergeist
+  CAPYBARA_DRIVER_MAP = {
+
+  }.freeze
+
+  DEFAULT_CAPYBARA_DRIVER = :poltergeist
+
+  def self.initialize_capybara_drivers!
+    @capybara_driver_name = CAPYBARA_DRIVER_MAP.fetch(@example_variable.application_name_under_test, :poltergeist)
+    Capybara.current_driver = @capybara_driver_name
+    Capybara.javascript_driver = @capybara_driver_name
   end
 end
 

--- a/spec/spec_support/test_runtime.rb
+++ b/spec/spec_support/test_runtime.rb
@@ -97,12 +97,15 @@ module ErrorReporter
 end
 
 module VerifyNetworkTraffic
+  # leverages network_traffic method of poltergeist driver to verify
+  # that all the network calls for static assets and 3rd party support
+  # are working on the site
   def self.report_network_traffic(driver:, test_handler:)
     @driver = driver
     @test_handler = test_handler
     return true unless driver_allows_network_traffic_verification?
     return true if ENV.fetch('SKIP_VERIFY_NETWORK_TRAFFIC', false)
-      ExampleLogging.current_logger.info(context: "verifying_all_network_traffic") do
+    ExampleLogging.current_logger.info(context: "verifying_all_network_traffic") do
       verify_network_traffic(driver: driver)
     end
   end

--- a/spec/spec_support/test_runtime.rb
+++ b/spec/spec_support/test_runtime.rb
@@ -66,3 +66,17 @@ module InitializeExample
     false
   end
 end
+
+module ErrorReporter
+  def self.conditionally_report_unsuccessful_scenario(example:)
+    @example = example
+    return true if successful_scenario?
+    # Leverage RSpec's logic to zero in on the location of failure from the exception backtrace
+    location_of_failure = RSpec.configuration.backtrace_formatter.format_backtrace(example.exception.backtrace).first
+    error(context: "FAILED example", location_of_failure: location_of_failure, message: @example.exception.message)
+  end
+
+  def self.successful_scenario?
+    @example.exception.nil?
+  end
+end


### PR DESCRIPTION
This PR is an attempt to reorganize the code into separate modules. 
* improves code documentation
* improve understanding of the flow
* keeps modules focussed on what they're intended for

This pre-work will make it easier to extend the logging framework in ExampleLogging module to integration tests. This PR could use some more refactor:
* How do I call the info/debug/error methods in test_runtime.rb instead of explicitly calling them like:
```ruby
error(context: "FAILED example")
# instead of:
ExampleLogging.current_logger.error(context: "FAILED example")
```