### PR TITLE
Mh login page

### DIFF
--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -158,7 +158,6 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
-    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
   end
@@ -167,7 +166,6 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
-    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
@@ -180,7 +178,6 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
-    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
@@ -193,7 +190,6 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
-    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
@@ -206,7 +202,6 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
-    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
@@ -219,7 +214,6 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
-    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
@@ -232,7 +226,6 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
-    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
@@ -245,7 +238,6 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
-    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
@@ -258,7 +250,6 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
-    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
@@ -271,7 +262,6 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
-    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
@@ -284,7 +274,6 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
-    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
@@ -297,7 +286,6 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
-    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
@@ -310,7 +298,6 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
-    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(page).not_to have_selector('.form-signin [name=submit]')
     expect(logged_in_home_page).to be_on_page
@@ -326,7 +313,6 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
-    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
   end
@@ -335,7 +321,6 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
-    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
@@ -348,7 +333,6 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
-    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
@@ -361,7 +345,6 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
-    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
@@ -374,7 +357,6 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
-    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
@@ -387,7 +369,6 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
-    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
@@ -400,7 +381,6 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
-    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
@@ -413,7 +393,6 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
-    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
@@ -426,7 +405,6 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
-    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
@@ -439,7 +417,6 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
-    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
@@ -452,7 +429,6 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
-    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
@@ -465,7 +441,6 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
-    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
@@ -481,7 +456,6 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
-    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
@@ -497,7 +471,6 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
-    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer

--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -153,15 +153,21 @@ feature 'Facet Navigation', js: true do
 end
 
 feature 'Logged In User (Account details NOT updated) Browsing', js: true do
-  let(:login_page) { Curate::Pages::LoginPage.new(current_logger, account_details_updated: false) }
+  let(:login_page) { LoginPage.new(current_logger, account_details_updated: false) }
   scenario "Log in" do
+    visit '/'
+    click_on('Log In')
     login_page.completeLogin
+    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
   end
 
   scenario "Manage My Works" do
+    visit '/'
+    click_on('Log In')
     login_page.completeLogin
+    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
@@ -171,7 +177,10 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
   end
 
   scenario "Visit Manage My Groups page" do
+    visit '/'
+    click_on('Log In')
     login_page.completeLogin
+    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
@@ -181,7 +190,10 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
   end
 
   scenario "Visit Manage My Collections page" do
+    visit '/'
+    click_on('Log In')
     login_page.completeLogin
+    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
@@ -191,7 +203,10 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
   end
 
   scenario "Visit Manage My Profile page" do
+    visit '/'
+    click_on('Log In')
     login_page.completeLogin
+    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
@@ -201,7 +216,10 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
   end
 
   scenario "Visit Deposit New Article page" do
+    visit '/'
+    click_on('Log In')
     login_page.completeLogin
+    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
@@ -211,7 +229,10 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
   end
 
   scenario "Visit Deposit New Dataset page" do
+    visit '/'
+    click_on('Log In')
     login_page.completeLogin
+    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
@@ -221,7 +242,10 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
   end
 
   scenario "Visit Deposit New Document page" do
+    visit '/'
+    click_on('Log In')
     login_page.completeLogin
+    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
@@ -231,7 +255,10 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
   end
 
   scenario "Visit Deposit New Image page" do
+    visit '/'
+    click_on('Log In')
     login_page.completeLogin
+    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
@@ -241,7 +268,10 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
   end
 
   scenario "Visit More Options page" do
+    visit '/'
+    click_on('Log In')
     login_page.completeLogin
+    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
@@ -251,7 +281,10 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
   end
 
   scenario "Visit Deposit New Audio page" do
+    visit '/'
+    click_on('Log In')
     login_page.completeLogin
+    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
@@ -261,7 +294,10 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
   end
 
   scenario "Visit Deposit New Senior Thesis page" do
+    visit '/'
+    click_on('Log In')
     login_page.completeLogin
+    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
@@ -271,8 +307,12 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
   end
 
   scenario "Log out" do
+    visit '/'
+    click_on('Log In')
     login_page.completeLogin
+    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
+    expect(page).not_to have_selector('.form-signin [name=submit]')
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
     click_on("Log Out")
@@ -281,15 +321,21 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
 end
 
 feature 'Logged In User (Account details updated) Browsing', js: true do
-  let(:login_page) { Curate::Pages::LoginPage.new(current_logger, account_details_updated: true) }
+  let(:login_page) { LoginPage.new(current_logger, account_details_updated: true) }
   scenario "Log in" do
+    visit '/'
+    click_on('Log In')
     login_page.completeLogin
+    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
   end
 
   scenario "Manage My Works", js: true do
+    visit '/'
+    click_on('Log In')
     login_page.completeLogin
+    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
@@ -299,7 +345,10 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
   end
 
   scenario "Visit Manage My Groups page" do
+    visit '/'
+    click_on('Log In')
     login_page.completeLogin
+    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
@@ -309,7 +358,10 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
   end
 
   scenario "Visit Manage My Collections page" do
+    visit '/'
+    click_on('Log In')
     login_page.completeLogin
+    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
@@ -319,7 +371,10 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
   end
 
   scenario "Visit Manage My Profile page" do
+    visit '/'
+    click_on('Log In')
     login_page.completeLogin
+    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
@@ -329,7 +384,10 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
   end
 
   scenario "Visit Manage My Delegates page" do
+    visit '/'
+    click_on('Log In')
     login_page.completeLogin
+    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer
@@ -339,7 +397,10 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
   end
 
   scenario "Visit Deposit New Article page" do
+    visit '/'
+    click_on('Log In')
     login_page.completeLogin
+    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
@@ -349,7 +410,10 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
   end
 
   scenario "Visit Deposit New Dataset page" do
+    visit '/'
+    click_on('Log In')
     login_page.completeLogin
+    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
@@ -359,7 +423,10 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
   end
 
   scenario "Visit Deposit New Document page" do
+    visit '/'
+    click_on('Log In')
     login_page.completeLogin
+    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
@@ -369,7 +436,10 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
   end
 
   scenario "Visit Deposit New Image page" do
+    visit '/'
+    click_on('Log In')
     login_page.completeLogin
+    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
@@ -379,7 +449,10 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
   end
 
   scenario "Visit More Options page" do
+    visit '/'
+    click_on('Log In')
     login_page.completeLogin
+    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
@@ -389,7 +462,10 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
   end
 
   scenario "Visit Deposit New Audio page" do
+    visit '/'
+    click_on('Log In')
     login_page.completeLogin
+    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
@@ -402,7 +478,10 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
   end
 
   scenario "Visit Deposit New Senior Thesis page" do
+    visit '/'
+    click_on('Log In')
     login_page.completeLogin
+    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openAddContentDrawer
@@ -415,7 +494,10 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
   end
 
   scenario "Log out" do
+    visit '/'
+    click_on('Log In')
     login_page.completeLogin
+    expect(page).not_to have_selector('.form-signin [name=submit]')
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.openActionsDrawer

--- a/spec/curate/pages/login_page.rb
+++ b/spec/curate/pages/login_page.rb
@@ -1,71 +1,8 @@
 # frozen_string_literal: true
-require 'csv'
-require 'curate/curate_spec_helper'
-module Curate
-  module Pages
-    class LoginPage
-      include Capybara::DSL
-      include CapybaraErrorIntel::DSL
-      attr_reader :userName
-      attr_reader :passWord
-      attr_reader :passCode
-      attr_reader :current_logger
-      attr_reader :account_details_updated
-
-      def inspect
-        "#<#{self.class} @userName=#{userName.inspect}>"
-      end
-
-      def initialize(logger, account_details_updated: false)
-        @account_details_updated = account_details_updated
-        @current_logger = logger
-        credentials = CSV.read(ENV['HOME']+"/test_data/QA/TestCredentials.csv")
-        # Filtering out items that satisfy the value of @account_details_updated
-        flagged_credentials = credentials.select{ |entry| cast_to_boolean(entry[3]) == @account_details_updated }
-        # randomly selecting a value from the remaining entries
-        credentials_to_use = flagged_credentials.sample
-        @userName = credentials_to_use[0]
-        @passWord = credentials_to_use[1]
-        @passCode = credentials_to_use[2]
-      end
-
-      def account_details_updated
-        @account_details_updated
-      end
-
-      def cast_to_boolean(value)
-        case value
-        when /^[TY]/i, '1'
-          true
-        else
-          false
-        end
-      end
-
-      def completeLogin
-        visit '/'
-        click_on('Log In')
-        page.has_selector?("input[name=username]")
-        page.has_selector?("input[name=password]")
-        page.has_selector?('.form-signin [name=submit]')
-        fill_in('username', with: userName)
-        fill_in('password', with: passWord)
-        find('.form-signin [name=submit]').click
-        # wait for first step of login to complete
-        page.has_selector?("input[name=passcode]")
-        fill_in('passcode', with: passCode)
-        # wait for second step of login to complete
-        page.has_selector?('.form-signin [name=submit]')
-        find('.form-signin [name=submit]').trigger('click')
-        current_logger.info(context: "Logging in user: #{userName}")
-        sleep(10)
-      end
-
-      def checkLoginPage
-        page.has_content?("Login to Curate")
-        find('#password')
-        find('button[name="submit"]', :text => 'LOGIN')
-      end
-    end
+class LoginPage
+  def checkLoginPage
+    page.has_content?("Login to Curate")
+    find('#password')
+    find('button[name="submit"]', :text => 'LOGIN')
   end
 end

--- a/spec/spec_support/cas_login.rb
+++ b/spec/spec_support/cas_login.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+require 'csv'
+
+class LoginPage
+  include Capybara::DSL
+  include CapybaraErrorIntel::DSL
+  attr_reader :userName
+  attr_reader :passWord
+  attr_reader :passCode
+  attr_reader :current_logger
+  attr_reader :account_details_updated
+
+  def inspect
+    "#<#{self.class} @userName=#{userName.inspect}>"
+  end
+
+  def initialize(logger, account_details_updated: (updated_set = false))
+    @account_details_updated = account_details_updated
+    @current_logger = logger
+    credentials = CSV.read(ENV['HOME']+"/test_data/QA/TestCredentials.csv")
+    # To remove the header (first element in the array) while maintaining array type
+    # so sample method is still available
+    credentials.shift
+    # Filtering out items that satisfy the value of @account_details_updated if specified)
+    # updated_set will only be nil if test specifies account_details_updated in initialization
+    if updated_set == nil
+      flagged_credentials = credentials.select{ |entry| cast_to_boolean(entry[3]) == @account_details_updated }
+      # randomly selecting a value from the remaining entries
+      credentials_to_use = flagged_credentials.sample
+    else
+      # randomly selecting a value from the remaining entries
+      credentials_to_use = credentials.sample
+    end
+    @userName = credentials_to_use[0]
+    @passWord = credentials_to_use[1]
+    @passCode = credentials_to_use[2]
+  end
+
+  def account_details_updated
+    @account_details_updated
+  end
+
+  def cast_to_boolean(value)
+    case value
+    when /^[TY]/i, '1'
+      true
+    else
+      false
+    end
+  end
+
+  def completeLogin
+    page.has_selector?('#username [name=username]')
+    page.has_selector?("#password [name=password]")
+    page.has_selector?('.form-signin [name=submit]')
+    fill_in('username', with: userName)
+    fill_in('password', with: passWord)
+    find('.form-signin [name=submit]').trigger('click')
+    page.has_selector?("input[name=passcode]")
+    fill_in('passcode', with: passCode)
+    page.has_selector?('.form-signin [name=submit]')
+    find('.form-signin [name=submit]').trigger('click')
+    current_logger.info(context: "Logging in user: #{userName}")
+  end
+end

--- a/spec/spec_support/cas_login.rb
+++ b/spec/spec_support/cas_login.rb
@@ -61,5 +61,7 @@ class LoginPage
     page.has_selector?('.form-signin [name=submit]')
     find('.form-signin [name=submit]').trigger('click')
     current_logger.info(context: "Logging in user: #{userName}")
+    # waits for it to leave the login page
+    page.has_no_selector?('.form-signin [name=submit]')
   end
 end

--- a/spec/spec_support/inject_sleep.rb
+++ b/spec/spec_support/inject_sleep.rb
@@ -42,3 +42,23 @@ module Capybara::Node::Matchers
     end
   end
 end
+
+module Capybara::Node::Matchers
+  def has_no_selector?(*args, &optional_filter_block)
+    assert_no_selector(*args, &optional_filter_block)
+  rescue Capybara::ExpectationNotMet, Exception => e
+    # if error
+    sleep(3)
+    begin
+      assert_no_selector(*args, &optional_filter_block)
+    rescue Capybara::ExpectationNotMet
+      # if still error
+      sleep(10)
+      begin
+        assert_no_selector(*args, &optional_filter_block)
+      rescue Capybara::ExpectationNotMet
+        return false
+      end
+    end
+  end
+end


### PR DESCRIPTION
Creates a global cas_login.rb page for tests to use in logged in scenarios. As many tests have a login page in the folder, creating a global login page allows for consistency across different tests and reduces amount of code needed.  This page also keeps track of if the a value was passed by the test for account_details_updated to use only the proper test credentials. The functional test for curate has ben updated to utilize this global login page and the curate/pages/login_page.rb has been updateed to only add the checkLoginPage method for the LoginPage class for the curate folder. Inject_sleep.rb has also been updated to include the has_no_selector? method because a sleep statement is sometimes necessary when testing if the completeLogin method logs in and loads the logged in homepage.