### PR TITLE
Mh verify network

### DIFF
--- a/spec/spec_support/inject_sleep.rb
+++ b/spec/spec_support/inject_sleep.rb
@@ -60,6 +60,8 @@ module Capybara::Node::Matchers
         return false
       end
     end
+  end
+end
 
 module Capybara::Node::Actions
   def fill_in(locator, options={})

--- a/spec/spec_support/swagger_handler.rb
+++ b/spec/spec_support/swagger_handler.rb
@@ -5,7 +5,7 @@
 class SwaggerHandler
   def self.operations(for_file_path:, config: ENV)
     @registry ||= {}
-    example_variable = ExampleVariableExtractor.call(path: for_file_path)
+    example_variable = ExampleVariableExtractor.call(path: for_file_path, config: config)
     @registry[example_variable] ||= new(example_variable: example_variable, config: config)
     @registry[example_variable].operations
   end

--- a/spec/spec_support/test_runtime.rb
+++ b/spec/spec_support/test_runtime.rb
@@ -105,9 +105,16 @@ module VerifyNetworkTraffic
     @test_handler = test_handler
     return true unless driver_allows_network_traffic_verification?
     return true if ENV.fetch('SKIP_VERIFY_NETWORK_TRAFFIC', false)
+    return true if test_needs_network_verification?
     ExampleLogging.current_logger.info(context: "verifying_all_network_traffic") do
       verify_network_traffic(driver: driver)
     end
+  end
+
+  def self.test_needs_network_verification?
+    input = ARGV.join.split('/')
+    #splits the test path into individual array elements
+    input.include?('integration')
   end
 
   def self.driver_allows_network_traffic_verification?
@@ -115,6 +122,7 @@ module VerifyNetworkTraffic
   end
 
   def self.verify_network_traffic(driver:)
+    require 'byebug'; debugger
     failed_resources = []
     driver.network_traffic.each do |request|
       request.response_parts.uniq(&:url).each do |response|
@@ -126,9 +134,10 @@ module VerifyNetworkTraffic
           ExampleLogging.current_logger.debug(context: "verifying_network_traffic", url: response.url, status_code: response.status)
         end
       end
-      @test_handler.expect(failed_resources).to @test_handler.be_empty, build_failed_messages_for(failed_resources)
     end
+    @test_handler.expect(failed_resources).to @test_handler.be_empty, build_failed_messages_for(failed_resources)
   end
+
 
   def self.build_failed_messages_for(failed_resources)
     text = "Resource Error:"

--- a/spec/spec_support/test_runtime.rb
+++ b/spec/spec_support/test_runtime.rb
@@ -105,7 +105,7 @@ module VerifyNetworkTraffic
     @test_handler = test_handler
     return true unless driver_allows_network_traffic_verification?
     return true if ENV.fetch('SKIP_VERIFY_NETWORK_TRAFFIC', false)
-    return true if test_needs_network_verification?
+    return true unless test_needs_network_verification?
     ExampleLogging.current_logger.info(context: "verifying_all_network_traffic") do
       verify_network_traffic(driver: driver)
     end
@@ -114,7 +114,7 @@ module VerifyNetworkTraffic
   def self.test_needs_network_verification?
     input = ARGV.join.split('/')
     #splits the test path into individual array elements
-    input.include?('integration')
+    !input.include?('integration')
   end
 
   def self.driver_allows_network_traffic_verification?
@@ -122,7 +122,6 @@ module VerifyNetworkTraffic
   end
 
   def self.verify_network_traffic(driver:)
-    require 'byebug'; debugger
     failed_resources = []
     driver.network_traffic.each do |request|
       request.response_parts.uniq(&:url).each do |response|


### PR DESCRIPTION
Updates test_runtime.rb to skip verify_network_traffic for integration tests as it is unnecessary for them. Also adds needed 'end' statements to inject_sleep.rb to make it functional.  Lastly, fixes the call to ExampleVariableExtractor in swagger_handler.rb since config: is necessary when calling that class.