### PR TITLE
Changes to crawler based on ESU requirements

### DIFF
--- a/spec/crawler/crawl/web_crawler_spec.rb
+++ b/spec/crawler/crawl/web_crawler_spec.rb
@@ -6,44 +6,49 @@ require "uri"
 require "set"
 feature 'Link Checker' do
   scenario 'Check Links' do
-    File.foreach(ENV["HOME"] + "/crawl_sites.txt") do |root_url|
-      root_url.strip!
-      current_logger.info(context: "Begin verifying site: #{root_url}")
-      encoded_url = URI.encode(root_url)
-      doc = Nokogiri::HTML(open(encoded_url))
-      links = doc.css('a')
-      hrefs = Set.new
-      links.each do |link|
-        href = link.attribute('href').to_s.strip
-        hrefs << href unless href.empty?
-      end
-      for href in hrefs do
-        if href.start_with?('/')
-          href = root_url + href
+    begin
+      File.foreach(ENV["HOME"] + "/crawl_sites.txt") do |root_url|
+        root_url.strip!
+        current_logger.info(context: "Begin verifying site: #{root_url}")
+        encoded_url = URI.encode(root_url)
+        doc = Nokogiri::HTML(open(encoded_url))
+        links = doc.css('a')
+        hrefs = Set.new
+        links.each do |link|
+          href = link.attribute('href').to_s.strip
+          hrefs << href unless href.empty?
         end
-        next if href =~ /\A#/ || href =~ /mailto:/ || href =~ /tel:/
-        uri = URI.parse(href)
-        http = Net::HTTP.new(uri.host, uri.port)
-        http.read_timeout = 5
-        http.open_timeout = 5
-        if uri.scheme == 'https'
-          http.use_ssl = true
-        end
-
-        begin
-          response = http.start() { |http|
-            http.get(uri)
-          }
-          if response.code.to_i >= 400 && response.code.to_i <= 599
-            current_logger.info(context: "crawler ERROR", url: href, status_code: response.code)
-          else
-            current_logger.debug(context: "Verified link", url: href, status_code: response.code)
+        for href in hrefs do
+          if href.start_with?('/')
+            href = root_url + href
           end
-        rescue Net::OpenTimeout
-          current_logger.error(context: "Could not reach URL in specified time", url: href, timeout_in_sec: http.open_timeout)
+          next if href =~ /\A#/ || href =~ /mailto:/ || href =~ /tel:/
+          uri = URI.parse(href)
+          http = Net::HTTP.new(uri.host, uri.port)
+          http.read_timeout = 5
+          http.open_timeout = 5
+          if uri.scheme == 'https'
+            http.use_ssl = true
+          end
+
+          begin
+            response = http.start() { |http|
+              http.get(uri)
+            }
+            if response.code.to_i >= 400 && response.code.to_i <= 599
+              current_logger.info(context: "crawler ERROR", url: href, status_code: response.code)
+            else
+              current_logger.debug(context: "Verified link", url: href, status_code: response.code)
+            end
+          rescue Net::OpenTimeout
+            current_logger.error(context: "Could not reach URL in specified time", url: href, timeout_in_sec: http.open_timeout)
+          end
         end
+        current_logger.info(context: "Finished verifying site: #{root_url}")
       end
-      current_logger.info(context: "Finished verifying site: #{root_url}")
+    rescue Errno::ENOENT
+      current_logger.error(context: "Expected input file", filename: ENV["HOME"] + "/crawl_sites.txt")
+      current_logger.error(context: "Create a local file with list of sites to verify")
     end
   end
 end

--- a/spec/crawler/crawl/web_crawler_spec.rb
+++ b/spec/crawler/crawl/web_crawler_spec.rb
@@ -8,7 +8,7 @@ feature 'Link Checker' do
   scenario 'Check Links' do
     File.foreach(ENV["HOME"] + "/crawl_sites.txt") do |root_url|
       root_url.strip!
-      current_logger.info(context: "Begin verifying: #{root_url}")
+      current_logger.info(context: "Begin verifying site: #{root_url}")
       encoded_url = URI.encode(root_url)
       doc = Nokogiri::HTML(open(encoded_url))
       links = doc.css('a')
@@ -37,13 +37,13 @@ feature 'Link Checker' do
           if response.code.to_i >= 400 && response.code.to_i <= 599
             current_logger.info(context: "crawler ERROR", url: href, status_code: response.code)
           else
-            current_logger.info(context: "Verified link", url: href, status_code: response.code)
+            current_logger.debug(context: "Verified link", url: href, status_code: response.code)
           end
         rescue Net::OpenTimeout
           current_logger.error(context: "Could not reach URL in specified time", url: href, timeout_in_sec: http.open_timeout)
         end
       end
-      current_logger.info(context: "Finished verifying: #{root_url}")
+      current_logger.info(context: "Finished verifying site: #{root_url}")
     end
   end
 end

--- a/spec/crawler/crawl/web_crawler_spec.rb
+++ b/spec/crawler/crawl/web_crawler_spec.rb
@@ -25,7 +25,9 @@ feature 'Link Checker' do
         uri = URI.parse(href)
         response = Net::HTTP.get_response(uri)
         if response.code.to_i >= 400 && response.code.to_i <= 599
-          current_logger.info(context: "crawler", url: href, status_code: response.code)
+          current_logger.info(context: "crawler ERROR", url: href, status_code: response.code)
+        else
+          current_logger.info(context: "Verified link", url: href, status_code: response.code)
         end
       end
       current_logger.info(context: "Finished verifying: #{root_url}")


### PR DESCRIPTION
These changes are adding some robustness to the site crawler based on requirements from ESU team. 
* Additional logging: being able to see which URLs are being hit.
* Showing a prompt to create a local input file
* Catching timeout to unreachable links and continue with rest of spec

I realize this isn't the best implementation based on our current ecosystem. This test works for now and we can refactor at a later point. 