### PR TITLE
Changing require statement to lower case

### DIFF
--- a/spec/crawler/crawl/web_crawler_spec.rb
+++ b/spec/crawler/crawl/web_crawler_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require 'crawler/crawler_spec_helper'
-require 'Nokogiri'
+require 'nokogiri'
 require "net/http"
 require "uri"
 require "set"


### PR DESCRIPTION
Linux server doesn't like upper case letters in require statements.
It needs to match the filename.