### PR TITLE
Splits request builder into different methods

### DIFF
--- a/spec/gatekeeper/integration/int_gatekeeper_spec.rb
+++ b/spec/gatekeeper/integration/int_gatekeeper_spec.rb
@@ -5,7 +5,7 @@ feature 'Gatekeeper API test' do
   SwaggerHandler.operations(for_file_path: __FILE__).each do |operation|
     scenario "calls #{operation.verb} #{operation.path}" do
       schema = RequestBuilder.new(current_logger, operation)
-      result = schema.method_case
+      result = schema.send_via_operation_verb
       current_response = ResponseValidator.new(operation, result)
       expect(current_response).to be_valid_response
     end

--- a/spec/gatekeeper/integration/int_gatekeeper_spec.rb
+++ b/spec/gatekeeper/integration/int_gatekeeper_spec.rb
@@ -4,8 +4,8 @@ require 'gatekeeper/gatekeeper_spec_helper'
 feature 'Gatekeeper API test' do
   SwaggerHandler.operations(for_file_path: __FILE__).each do |operation|
     scenario "calls #{operation.verb} #{operation.path}" do
-      schema = RequestBuilder.new(operation)
-      result = schema.send_security_vs_none
+      schema = RequestBuilder.new(current_logger, operation)
+      result = schema.method_case
       current_response = ResponseValidator.new(operation, result)
       expect(current_response).to be_valid_response
     end

--- a/spec/hours/integration/int_hours_spec.rb
+++ b/spec/hours/integration/int_hours_spec.rb
@@ -5,7 +5,7 @@ feature 'Hours API test' do
   SwaggerHandler.operations(for_file_path: __FILE__).each do |operation|
     scenario "calls #{operation.verb} #{operation.path}" do
       schema = RequestBuilder.new(current_logger, operation)
-      result = schema.method_case
+      result = schema.send_via_operation_verb
       current_response = ResponseValidator.new(operation, result)
       expect(current_response).to be_valid_response
     end

--- a/spec/hours/integration/int_hours_spec.rb
+++ b/spec/hours/integration/int_hours_spec.rb
@@ -4,7 +4,8 @@ require 'hours/hours_spec_helper'
 feature 'Hours API test' do
   SwaggerHandler.operations(for_file_path: __FILE__).each do |operation|
     scenario "calls #{operation.verb} #{operation.path}" do
-      result = public_send(operation.verb, operation.url)
+      schema = RequestBuilder.new(current_logger, operation)
+      result = schema.method_case
       current_response = ResponseValidator.new(operation, result)
       expect(current_response).to be_valid_response
     end

--- a/spec/spec_support/request_builder.rb
+++ b/spec/spec_support/request_builder.rb
@@ -5,7 +5,7 @@ require 'csv'
 
 class RequestBuilder
   attr_reader :current_logger
-  
+
   def initialize(logger,operation)
     @current_operation = operation
     @security_name = get_security_name
@@ -35,7 +35,8 @@ class RequestBuilder
     name = schema_security.name
   end
 
-  def method_case(*body)
+  def send_via_operation_verb(*body)
+    # determines which method verb the current opertation has and sends request accordingly
     security = check_security
     case (@current_operation.verb.to_s)
     when "get"

--- a/spec/spec_support/request_builder.rb
+++ b/spec/spec_support/request_builder.rb
@@ -1,35 +1,82 @@
 # frozen_string_literal: true
 # This class provides a mechanism for adding header fields in a request
 # like authorization headers.
+require 'csv'
 
 class RequestBuilder
-  def initialize(operation)
+  attr_reader :current_logger
+  
+  def initialize(logger,operation)
     @current_operation = operation
+    @security_name = get_security_name
+    @token = get_token
+    @current_logger = logger
   end
 
   # Identifies if the API has security or not then sends request accordingly
-  def send_security_vs_none
-    if not_option?
-      # Get schema of the response
-      schema = @current_operation.responses.values[0].schema.root
-      if schema.keys.include?('securityDefinitions')
-        # Get the type, name, and in fields of the security
-        schema_security = schema.securityDefinitions.values[0]
-        # Gets the name of the security to use for authorization
-        name = schema_security.name
-        user_home_dir = File.expand_path('~')
-        # Accesses the file to get the jwt token
-        yaml = YAML.load_file(File.join("#{user_home_dir}", 'test_data/QA/jwt_token.yml'))
-        token = yaml.fetch('token')
-        # Uses the name and token variables bypass security
-        RestClient.public_send(@current_operation.verb, @current_operation.url, "#{name}": "#{token}")
+  def check_security
+    schema = @current_operation.responses.values[0].schema.root
+    schema.keys.include?('securityDefinitions')
+  end
+
+  def get_token
+    user_home_dir = File.expand_path('~')
+    # Accesses the file to get the jwt token
+    yaml = YAML.load_file(File.join("#{user_home_dir}", 'test_data/QA/jwt_token.yml'))
+    token = yaml.fetch('token')
+  end
+
+  def get_security_name
+    # Get schema of the response
+    schema = @current_operation.responses.values[0].schema.root
+    # Get the type, name, and in fields of the security
+    schema_security = schema.securityDefinitions.values[0]
+    # Gets the name of the security to use for authorization
+    name = schema_security.name
+  end
+
+  def method_case(*body)
+    security = check_security
+    case (@current_operation.verb.to_s)
+    when "get"
+      current_logger.info(context: "making GET request")
+      if security
+        RestClient.public_send(@current_operation.verb, @current_operation.url, "#{@security_name}": "#{@token}")
       else
         RestClient.public_send(@current_operation.verb, @current_operation.url)
       end
+    when "post"
+      current_logger.info(context: "making POST request")
+      if security
+        RestClient.public_send(@current_operation.verb, @current_operation.url, body, "#{@security_name}": "#{@token}")
+      else
+        RestClient.public_send(@current_operation.verb, @current_operation.url, body)
+      end
+    when "put" #might need  specific item when testing
+      current_logger.info(context: "naking PUT request")
+      if security
+        RestClient.public_send(@current_operation.verb, @current_operation.url, body, "#{@security_name}": "#{@token}")
+      else
+        RestClient.public_send(@current_operation.verb, @current_operation.url, body)
+      end
+    when "patch" #might need specific item when testing
+      current_logger.info(context: "making PATCH request")
+      if security
+        RestClient.public_send(@current_operation.verb, @current_operation.url, body, "#{@security_name}": "#{@token}")
+      else
+        RestClient.public_send(@current_operation.verb, @current_operation.url, body)
+      end
+    when "delete" #might need specific item when testing
+      current_logger.info(context: "making DELETE request")
+      if security
+        RestClient.public_send(@current_operation.verb, @current_operation.url, "#{@security_name}": "#{@token}")
+      else
+        RestClient.public_send(@current_operation.verb, @current_operation.url)
+      end
+    when "options"
+      current_logger.info(context: "OPTIONS method - no request made")
+    else
+      current_logger.info(context: "Unknown verb - no request made")
     end
-  end
-
-  def not_option?
-    @current_operation.verb.to_s != "options"
   end
 end


### PR DESCRIPTION
RequestBuilder is now split into different methods to clarify the code.
In addition, a method_case method was added to create a case-when series
based on the operation.verb request (e.g. get, post). This method has an
optional argument *body as certain operation.verbs (such as post, put
) need a body to added in the public_send request.  RequestBuilder
also now has a logger as an instance variable so the status of the
request can be logged.  The hours and gatekeeper int. tests have been
updated to use the new RequestBuilder.