### PR TITLE
Hp usurper tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,4 +23,5 @@ group :testcontroller do
   gem 'aws-sdk'
   gem 'airborne'
   gem 'contentful'
+  gem 'contentful-management'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,10 @@ GEM
     contentful (2.1.0)
       http (> 0.8, < 3.0)
       multi_json (~> 1)
+    contentful-management (1.8.0)
+      http (> 1.0, < 3.0)
+      json (~> 1.8)
+      multi_json (~> 1)
     diff-lcs (1.2.5)
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
@@ -72,6 +76,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.7.0)
     jmespath (1.3.1)
+    json (1.8.6)
     json-schema (2.8.0)
       addressable (>= 2.4)
     launchy (2.4.3)
@@ -170,6 +175,7 @@ DEPENDENCIES
   capybara-screenshot
   capybara_error_intel
   contentful
+  contentful-management
   logging
   poltergeist
   rake

--- a/spec/spec_support/contentful_handler.rb
+++ b/spec/spec_support/contentful_handler.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+# This class provides support to interact with the following contentful APIs:
+# * Content Delivery API: https://www.contentful.com/developers/docs/references/content-delivery-api/
+# * Content Management API: https://www.contentful.com/developers/docs/references/content-management-api/
+# * Content Preview API: https://www.contentful.com/developers/docs/references/content-preview-api/
+# * Images API: https://www.contentful.com/developers/docs/references/images-api/
+
+class ContentfulHandler
+  def initialize(for_file_path:, config:, current_logger:)
+    @current_logger = current_logger
+    example_variable = ExampleVariableExtractor.call(path: for_file_path, config: config)
+    read_contentful_tokens
+    create_entry
+  end
+
+  def read_contentful_tokens
+    user_home_dir = File.expand_path('~')
+    cf_key_file = YAML.load_file(File.join(user_home_dir.to_s, 'test_data/QA/cf_api_key.yml'))
+    @space_id = cf_key_file.fetch('QA_key').fetch('space_id')
+    @cdn_token = cf_key_file.fetch('QA_key').fetch('cdn_token')
+    @preview_token = cf_key_file.fetch('QA_key').fetch('preview_token')
+    @personal_access_token = cf_key_file.fetch('QA_key').fetch('personal_access_token')
+  end
+
+  def create_entry
+    create_client
+    content_type = @client.content_types.find(@space_id, 'page')
+    @title_for_entry = 'Testing page ' + RunIdentifier.get
+    @current_logger.info(context: "Creating page in contentful", page_title: @title_for_entry)
+    @entry = @client.entries.create(content_type, title: @title_for_entry)
+  end
+
+  def create_client
+    @client = Contentful::Management::Client.new(@personal_access_token)
+  end
+
+  def in_contentful?
+    if @entry.title == @title_for_entry
+      @current_logger.info(context: "Page created in contentful", page_title: @title_for_entry)
+    end
+  end
+end

--- a/spec/usurper/integration/int_usurper_spec.rb
+++ b/spec/usurper/integration/int_usurper_spec.rb
@@ -2,10 +2,14 @@
 require 'usurper/usurper_spec_helper'
 
 feature 'Test for Usurper content management API' do
-  scenario "Creates an entry" do
+  scenario "Creates, previews, and deletes an entry" do
     created_entry = ContentfulHandler.new(for_file_path: __FILE__, config: ENV, current_logger: current_logger)
     expect(created_entry).to be_in_contentful
     # Write a function to preview the entry just created using Content Preview API
+    created_entry.make_entry_previewable
+    visit "/#{created_entry.slug_for_entry}?preview=true"
     # Remove the entry created using the Content Management API
+    created_entry.delete_entry
+    expect(created_entry).to be_deleted
   end
 end

--- a/spec/usurper/integration/int_usurper_spec.rb
+++ b/spec/usurper/integration/int_usurper_spec.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+require 'viceroy/viceroy_spec_helper'

--- a/spec/usurper/integration/int_usurper_spec.rb
+++ b/spec/usurper/integration/int_usurper_spec.rb
@@ -1,2 +1,11 @@
 # frozen_string_literal: true
-require 'viceroy/viceroy_spec_helper'
+require 'usurper/usurper_spec_helper'
+
+feature 'Test for Usurper content management API' do
+  scenario "Creates an entry" do
+    created_entry = ContentfulHandler.new(for_file_path: __FILE__, config: ENV, current_logger: current_logger)
+    expect(created_entry).to be_in_contentful
+    # Write a function to preview the entry just created using Content Preview API
+    # Remove the entry created using the Content Management API
+  end
+end

--- a/spec/usurper/usurper_config.yml
+++ b/spec/usurper/usurper_config.yml
@@ -1,0 +1,1 @@
+prod: https://api.contentful.com

--- a/spec/usurper/usurper_config.yml
+++ b/spec/usurper/usurper_config.yml
@@ -1,1 +1,1 @@
-prod: https://api.contentful.com
+prod: https://alpha.library.nd.edu

--- a/spec/usurper/usurper_repo_config.yml
+++ b/spec/usurper/usurper_repo_config.yml
@@ -1,0 +1,1 @@
+repo_url: https://github.com/ndlib/usurper_content

--- a/spec/usurper/usurper_spec_helper.rb
+++ b/spec/usurper/usurper_spec_helper.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+require 'spec_helper'

--- a/spec/usurper/usurper_spec_helper.rb
+++ b/spec/usurper/usurper_spec_helper.rb
@@ -1,2 +1,3 @@
 # frozen_string_literal: true
 require 'spec_helper'
+require 'contentful/management'

--- a/spec/usurper/usurper_spec_helper.rb
+++ b/spec/usurper/usurper_spec_helper.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 require 'spec_helper'
 require 'contentful/management'
+require 'contentful'


### PR DESCRIPTION
Integration test for the usurper content api.  Creates, previews, then deletes an entry in contentful in  order to test the api. Uses https://alpha.library.nd.edu as its prod config because it visits the website with the name of the entry as a slug to make sure the entry is previewed.