### PR TITLE
Adding ensure block to clean-up Contentful

### DIFF
--- a/spec/spec_support/contentful_handler.rb
+++ b/spec/spec_support/contentful_handler.rb
@@ -6,34 +6,34 @@
 # * Images API: https://www.contentful.com/developers/docs/references/images-api/
 
 class ContentfulHandler
+  def self.create(for_file_path:, config:, current_logger:)
+    handler = new(for_file_path: for_file_path, config: config, current_logger: current_logger)
+    entry = handler.create_entry
+    yield(entry)
+  ensure
+    begin
+      entry.delete_entry
+    rescue StandardError => e
+      @current_logger.debug(context: "Failed to clean up entry. This may be okay, as it could have already been cleaned up. Exception: #{e.inspect}", page_title: entry.title_for_entry)
+    end
+  end
+
+  # Prefer the .create method instead; It will ensure proper clean-up
+  private_class_method :new
+
   attr_reader :slug_for_entry
   def initialize(for_file_path:, config:, current_logger:)
     @current_logger = current_logger
-    example_variable = ExampleVariableExtractor.call(path: for_file_path, config: config)
     read_contentful_tokens
-    create_entry
-  end
-
-  def read_contentful_tokens
-    user_home_dir = File.expand_path('~')
-    cf_key_file = YAML.load_file(File.join(user_home_dir.to_s, 'test_data/QA/cf_api_key.yml'))
-    @space_id = cf_key_file.fetch('QA_key').fetch('space_id')
-    @cdn_token = cf_key_file.fetch('QA_key').fetch('cdn_token')
-    @preview_token = cf_key_file.fetch('QA_key').fetch('preview_token')
-    @personal_access_token = cf_key_file.fetch('QA_key').fetch('personal_access_token')
+    set_client!
   end
 
   def create_entry
-    create_client
     @content_type = @client.content_types.find(@space_id, 'page')
     @title_for_entry = 'Testing_page_' + RunIdentifier.get
     @slug_for_entry = @title_for_entry
     @current_logger.info(context: "Creating page in contentful", page_title: @title_for_entry)
     @entry = @client.entries.create(@content_type, title: @title_for_entry, slug: @slug_for_entry)
-  end
-
-  def create_client
-    @client = Contentful::Management::Client.new(@personal_access_token)
   end
 
   def in_contentful?
@@ -45,7 +45,7 @@ class ContentfulHandler
   def make_entry_previewable
     @current_logger.info(context: "Making page previewable", page_title: @title_for_entry)
     preview_client = Contentful::Client.new(space: "#{@space_id}", access_token: "#{@preview_token}", api_url: 'preview.contentful.com')
-    previewed_entry = preview_client.entry("#{@entry.id}")
+    preview_client.entry("#{@entry.id}")
   end
 
   def delete_entry
@@ -57,5 +57,19 @@ class ContentfulHandler
     if @client.entries.find(@space_id, @entry.id).message == "The resource could not be found."
       @current_logger.info(context: "Page has been deleted", page_title: @title_for_entry)
     end
+  end
+
+  private
+
+  def read_contentful_tokens
+    cf_key_file = YAML.load_file(File.join(ENV.fetch('HOME'), 'test_data/QA/cf_api_key.yml'))
+    @space_id = cf_key_file.fetch('QA_key').fetch('space_id')
+    @cdn_token = cf_key_file.fetch('QA_key').fetch('cdn_token')
+    @preview_token = cf_key_file.fetch('QA_key').fetch('preview_token')
+    @personal_access_token = cf_key_file.fetch('QA_key').fetch('personal_access_token')
+  end
+
+  def set_client!
+    @client = Contentful::Management::Client.new(@personal_access_token)
   end
 end

--- a/spec/usurper/integration/int_usurper_spec.rb
+++ b/spec/usurper/integration/int_usurper_spec.rb
@@ -3,13 +3,14 @@ require 'usurper/usurper_spec_helper'
 
 feature 'Test for Usurper content management API' do
   scenario "Creates, previews, and deletes an entry" do
-    created_entry = ContentfulHandler.new(for_file_path: __FILE__, config: ENV, current_logger: current_logger)
-    expect(created_entry).to be_in_contentful
-    # Write a function to preview the entry just created using Content Preview API
-    created_entry.make_entry_previewable
-    visit "/#{created_entry.slug_for_entry}?preview=true"
-    # Remove the entry created using the Content Management API
-    created_entry.delete_entry
-    expect(created_entry).to be_deleted
+    ContentfulHandler.create(for_file_path: __FILE__, config: ENV, current_logger: current_logger) do |created_entry|
+      expect(created_entry).to be_in_contentful
+      # Write a function to preview the entry just created using Content Preview API
+      created_entry.make_entry_previewable
+      visit "/#{created_entry.slug_for_entry}?preview=true"
+      # Remove the entry created using the Content Management API
+      created_entry.delete_entry
+      expect(created_entry).to be_deleted
+    end
   end
 end


### PR DESCRIPTION
Prior to this commit, if an exception was raised during the test, it
could've left a test page in Contentful. This provides another layer of
insurance that we are cleaning up Contentful.