### PR TITLE
ResponsiveHelpers module for changing window size

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,6 +47,8 @@ RSpec.configure do |config|
     ExampleLogging.current_logger = @current_logger
     InitializeExample.initialize_app_host(example: rspec_example, config: ENV)
     InitializeExample.initialize_capybara_drivers!
+    # Set the window size only after capybara drivers are initialized
+    ResponsiveHelpers.resize_window_default('landscape')
   end
 
   config.after(:example) do |rspec_example|

--- a/spec/spec_support/responsive_helper.rb
+++ b/spec/spec_support/responsive_helper.rb
@@ -9,11 +9,9 @@ module ResponsiveHelpers
   end
 
   def self.resize_window_default(mode)
-    require 'byebug'; debugger
     resize_window_by([1280, 800], mode)
   end
 
-  private
   def self.resize_window_by(size, mode)
     if mode == 'landscape'
       Capybara.current_window.resize_to(size[0], size[1])

--- a/spec/spec_support/responsive_helper.rb
+++ b/spec/spec_support/responsive_helper.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+module ResponsiveHelpers
+  def self.resize_window_to_mobile(mode)
+    resize_window_by([640, 480], mode)
+  end
+
+  def self.resize_window_to_tablet(mode)
+    resize_window_by([1024, 768], mode)
+  end
+
+  def self.resize_window_default(mode)
+    require 'byebug'; debugger
+    resize_window_by([1280, 800], mode)
+  end
+
+  private
+  def self.resize_window_by(size, mode)
+    if mode == 'landscape'
+      Capybara.current_window.resize_to(size[0], size[1])
+    elsif mode == 'portrait'
+      Capybara.current_window.resize_to(size[1], size[0])
+    end
+  end
+end


### PR DESCRIPTION
This module provides methods to set the window size for devices in
landscape and portrait modes.
By default, I'm setting the window size to 1280x800 in landscape
which simulates desktop mode.