### PR TITLE
Updating capfile lock to 3.8.2

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 # config valid only for current version of Capistrano
-lock '3.7.1'
+lock '3.8.2'
 #############################################################
 #  Settings
 #############################################################


### PR DESCRIPTION
Jenkins was unable to deploy the repo out to testcontroller01.
Kept complaining:
```console
Capfile locked at 3.7.1, but 3.8.2 is loaded
```