### PR TITLE
Hp recommend engine

### DIFF
--- a/spec/recommendationEngine/integration/int_recommendationEngine_spec.rb
+++ b/spec/recommendationEngine/integration/int_recommendationEngine_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'recommendationEngine/recommendationEngine_spec_helper'
+
+feature 'Recommendation Engine API test' do
+  SwaggerHandler.operations(for_file_path: __FILE__).each do |operation|
+    scenario "calls #{operation.verb} #{operation.path}" do
+      schema = RequestBuilder.new(current_logger, operation)
+      result = schema.send_via_operation_verb
+      current_response = ResponseValidator.new(operation, result)
+      expect(current_response).to be_valid_response
+    end
+  end
+end

--- a/spec/recommendationEngine/recommendationEngine_config.yml
+++ b/spec/recommendationEngine/recommendationEngine_config.yml
@@ -1,0 +1,1 @@
+prod: jello

--- a/spec/recommendationEngine/recommendationEngine_repo_config.yml
+++ b/spec/recommendationEngine/recommendationEngine_repo_config.yml
@@ -1,0 +1,1 @@
+repo_url: https://github.com/ndlib/recommendation_engine

--- a/spec/recommendationEngine/recommendationEngine_spec_helper.rb
+++ b/spec/recommendationEngine/recommendationEngine_spec_helper.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'spec_helper'

--- a/spec/spec_support/path_parameterizer.rb
+++ b/spec/spec_support/path_parameterizer.rb
@@ -13,7 +13,7 @@ module PathParameterizer
   def self.call(logger:, application_name_under_test:, path:, context: nil)
     original_path = path
     parameters = path.scan(PARAMETER_TOKEN_REGEXP)
-    if parameters.nil?
+    if parameters.empty?
       logger.debug(context: "Path is not parameterized", path: path)
       return path
     else

--- a/spec/spec_support/request_builder.rb
+++ b/spec/spec_support/request_builder.rb
@@ -17,8 +17,12 @@ class RequestBuilder
 
   # Identifies if the API has security or not then sends request accordingly
   def check_security
-    schema = @current_operation.responses.values[0].schema.root
-    schema.keys.include?('securityDefinitions')
+    if @current_operation.responses.values[0].schema.nil?
+      return false
+    else
+      schema = @current_operation.responses.values[0].schema.root
+      schema.keys.include?('securityDefinitions')
+    end
   end
 
   def apply_parameter_to_parameterized_path!

--- a/spec/spec_support/request_builder.rb
+++ b/spec/spec_support/request_builder.rb
@@ -92,8 +92,16 @@ class RequestBuilder
       end
     when "options"
       current_logger.info(context: "OPTIONS method - no request made")
+      create_mock_response_for_options
     else
       current_logger.info(context: "Unknown verb - no request made")
     end
+  end
+
+  def create_mock_response_for_options
+    mock_body = "{message: 'Mocked up body for 'options' method}"
+    mock_response = Net::HTTPResponse.new('1.1', '200', 'Mock message')
+    mock_request = RestClient::Request.new(url: 'http://example.com', method: :options)
+    RestClient::Response.create(mock_body, mock_response, mock_request)
   end
 end

--- a/spec/spec_support/response_validator.rb
+++ b/spec/spec_support/response_validator.rb
@@ -8,6 +8,7 @@ class ResponseValidator
   end
 
   def valid_response?
+    return true if @current_result.request.method == 'options'
     status_response_ok? &&
       valid_schema?
   end


### PR DESCRIPTION
* Creates a test suite for the recommendation engine API
* Adds an if condition to skip checking for security token if schema is missing in the swagger definition
* Adds logic for returning a mock response for 'options' method

This test will fail becuase the get 'libraryinfo' endpoint for recommednation engine is query parameterized. I'm working on another pull request to accomodate that.