### PR TITLE
Hp curate fixes

### DIFF
--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -132,7 +132,9 @@ feature 'Facet Navigation', js: true do
     ['Department or Unit', 'Collection'].shuffle.each do |facet_name|
       current_logger.info(context: "Processing Facet: #{facet_name}")
       expect(page).not_to have_selector("#ajax-modal", visible: true)
-      click_on(facet_name)
+      within('.facets') do
+        click_on(facet_name)
+      end
       expect(page).to have_selector('#ajax-modal', visible: true)
       expect(page).to have_content(facet_name)
       within('#ajax-modal') do

--- a/spec/curate/pages/show_article.rb
+++ b/spec/curate/pages/show_article.rb
@@ -39,7 +39,7 @@ module Curate
         has_content?(@article_title)
         # Make sure that the Abstract and Attributes sections have text
         within("article.abstract.descriptive-text") do
-          find('p')
+          page.has_selector?("p", minimum: 1)
         end
         within("table.table.table-striped") do
           first('p')


### PR DESCRIPTION
These changes make the test suite more robust, avoiding ambiguous match errors.