### PR TITLE
Alters the response_validator to check for levels of $refs

### DIFF
--- a/spec/classes/classes_config.yml
+++ b/spec/classes/classes_config.yml
@@ -1,2 +1,2 @@
-dev: https://unauxwjiml.execute-api.us-east-1.amazonaws.com/dev/
+dev: https://webrenovation-beta.library.nd.edu/classesapi/
 prod: jello

--- a/spec/gatekeeper/gatekeeper_config.yml
+++ b/spec/gatekeeper/gatekeeper_config.yml
@@ -1,3 +1,3 @@
-dev: https://fec9x3dsdg.execute-api.us-east-1.amazonaws.com/
+dev: https://webrenovation-beta.library.nd.edu/gatekeeper/
 pprd: jello
 prod: jello

--- a/spec/hours/hours_config.yml
+++ b/spec/hours/hours_config.yml
@@ -1,3 +1,3 @@
-dev: https://g72i6y2qnj.execute-api.us-east-1.amazonaws.com
+dev: https://webrenovation-beta.library.nd.edu/monarchlibguides/
 pprd: jello
 prod: jello

--- a/spec/recommendationEngine/recommendationEngine_config.yml
+++ b/spec/recommendationEngine/recommendationEngine_config.yml
@@ -1,2 +1,2 @@
 prod: jello
-dev: https://nydixnx3ug.execute-api.us-east-1.amazonaws.com/prod/
+dev: https://webrenovation-beta.library.nd.edu/recommendationengine/

--- a/spec/recommendationEngine/recommendationEngine_config.yml
+++ b/spec/recommendationEngine/recommendationEngine_config.yml
@@ -1,1 +1,2 @@
 prod: jello
+dev: https://nydixnx3ug.execute-api.us-east-1.amazonaws.com/prod/

--- a/spec/usurper/usurper_config.yml
+++ b/spec/usurper/usurper_config.yml
@@ -1,1 +1,2 @@
-prod: https://alpha.library.nd.edu
+pprd: https://alpha.library.nd.edu
+prod: https://beta.library.nd.edu/


### PR DESCRIPTION
As some APIs have other $refs in the definition of another $ref, the
ResponseValidator now checks for those deeper levels of $refs to get keys for
all of the definitions so that the API result is fully tested against
all of the expected keys. The test does the same thing for the results to make
sure all of the keys are accounted for.

The config file also no has the proper location for the API