### PR TITLE
Updates sipity functional test to use global LoginPage

### DIFF
--- a/spec/sipity/functional/etd_spec.rb
+++ b/spec/sipity/functional/etd_spec.rb
@@ -3,7 +3,7 @@ require 'sipity/sipity_spec_helper'
 
 feature 'First Time User', js: true do
   let(:casLogin) { LoginPage.new(current_logger, terms_of_service_accepted: false) }
-  scenario 'FIRST TIME User Sign In', js: true do
+  scenario 'FIRST TIME User Sign In', :validates_login, js: true  do
     sign_in
     welcome_page = Sipity::Pages::ETDWelcomePage.new
     expect(welcome_page).to be_on_page
@@ -19,7 +19,7 @@ feature 'User Browsing', js: true do
     visit_home
   end
 
-  scenario 'RETURN User Sign In', js: true do
+  scenario 'RETURN User Sign In', :validates_login, js: true do
     returning_user_sign_in
   end
 

--- a/spec/sipity/functional/etd_spec.rb
+++ b/spec/sipity/functional/etd_spec.rb
@@ -2,7 +2,7 @@
 require 'sipity/sipity_spec_helper'
 
 feature 'First Time User', js: true do
-  let(:casLogin) { Sipity::Pages::CASLoginPage.new(current_logger, terms_of_service_accepted: false) }
+  let(:casLogin) { LoginPage.new(current_logger, terms_of_service_accepted: false) }
   scenario 'FIRST TIME User Sign In', js: true do
     sign_in
     welcome_page = Sipity::Pages::ETDWelcomePage.new
@@ -14,7 +14,7 @@ feature 'First Time User', js: true do
 end
 
 feature 'User Browsing', js: true do
-  let(:casLogin) { Sipity::Pages::CASLoginPage.new(current_logger, terms_of_service_accepted: true) }
+  let(:casLogin) { LoginPage.new(current_logger, terms_of_service_accepted: true) }
   scenario 'Visit Homepage' do
     visit_home
   end
@@ -74,7 +74,7 @@ def sign_in
     find_link('Sign in').click
   end
   expect(casLogin).to be_on_page
-  casLogin.complete_login
+  casLogin.completeLogin
 end
 
 def returning_user_sign_in

--- a/spec/sipity/pages/submitted_etd.rb
+++ b/spec/sipity/pages/submitted_etd.rb
@@ -20,6 +20,7 @@ module Sipity
       end
 
       def valid_page_content?
+        find('.btn.btn-primary.login').click
         find("div.btn-group.my-actions").click
         find("div.btn-group.my-actions.open")
         has_content?("My Works")

--- a/spec/spec_support/cas_login.rb
+++ b/spec/spec_support/cas_login.rb
@@ -18,8 +18,9 @@ class LoginPage
   end
   alias to_s inspect
 
-  def initialize(logger, account_details_updated: (updated_set = false))
+  def initialize(logger, account_details_updated: (updated_set = false), terms_of_service_accepted: (accepted = true))
     @account_details_updated = account_details_updated
+    @terms_of_service_accepted = terms_of_service_accepted
     @current_logger = logger
     credentials = CSV.read(ENV['HOME']+"/test_data/QA/TestCredentials.csv")
     # To remove the header (first element in the array) while maintaining array type
@@ -29,6 +30,10 @@ class LoginPage
     # updated_set will only be nil if test specifies account_details_updated in initialization
     if updated_set == nil
       flagged_credentials = credentials.select{ |entry| cast_to_boolean(entry[3]) == @account_details_updated }
+      # randomly selecting a value from the remaining entries
+      credentials_to_use = flagged_credentials.sample
+    elsif accepted == nil
+      flagged_credentials = credentials.select{ |entry| cast_to_boolean(entry[4]) == @terms_of_service_accepted }
       # randomly selecting a value from the remaining entries
       credentials_to_use = flagged_credentials.sample
     else


### PR DESCRIPTION
Instead of using the local login page, the sipity scenarios now use the
global login page.

The submitted_etd.rb file was altered to account for a missing step
in testing the page by clicking the login button.

The cas_login global page now has terms_of_service_accepted as a
instance variable so that accounts which have accepted the terms and
the ones which have no are all tested.