### PR TITLE
Updates the response validator for api testing

### DIFF
--- a/spec/spec_support/response_validator.rb
+++ b/spec/spec_support/response_validator.rb
@@ -18,6 +18,28 @@ class ResponseValidator
   end
 
   def valid_schema?
+    # Making sure all the properties listed in Swagger definition
+    # are present in the result body
+    result_keys = get_result_keys.sort
+    schema_properties = get_schema_properties.sort
+    (result_keys & schema_properties).sort == schema_properties.sort
+  end
+
+  def get_result_keys
+    # Parse result body as JSON and find the keys
+    result_keys = JSON.parse(@current_result.body).keys
+    # finds the deeper level results keys for each key
+    result_keys.each do |key|
+      # if the class is not an array, it means there are no more keys at that level
+      if JSON.parse(@current_result.body)[key].class == Array
+        # adds the deeper level result keys to the result_keys list
+        result_keys += JSON.parse(@current_result.body)[key][0].keys
+      end
+    end
+    return result_keys
+  end
+
+  def get_schema_properties
     ## Snippet below is a workaround to the resolve_refs method.
     # Get the schema for key[0]
     response_schema = @current_operation.responses.values[0]
@@ -29,27 +51,24 @@ class ResponseValidator
     resolved_schema = response_schema.schema.root.definitions
     # Resolve definition properties
     schema_properties = resolved_schema.fetch("#{ref}").properties.keys
-      # While statement tests if definition of the the schema has more $ref to get keys from other schemas
-    while resolved_schema.fetch("#{ref}").properties.values[0].keys.include?('$ref')
-      # gets the keys from deeper level $ref path
-      key_ref = resolved_schema.fetch("#{ref}").properties.values[0].values[0]
-      # turns the $ref path into a specfic $ref
-      ref = key_ref.split('#/definitions/').join
-      # adds the keys from deeper level schema
-      schema_properties += resolved_schema.fetch("#{ref}").properties.keys
-    end
-    # Parse result body as JSON and find the keys
-    result_keys = JSON.parse(@current_result.body).keys
-    # finds the deeper level results keys for each key
-    result_keys.each do |key|
-      # if the class is not an array, it means there are no more keys at that level
-      if JSON.parse(@current_result.body)[key].class == Array
-        # adds the deeper level result keys to the result_keys list
-        result_keys += JSON.parse(@current_result.body)[key][0].keys
+    schema_properties.each do |property|
+      # needed to identify if items property exists
+      definition_ref = resolved_schema.fetch("#{ref}").properties[property]
+      # if items key exists it needs to be used
+      if definition_ref.keys.include?('items')
+        key_ref = definition_ref.items.values[0]
+        ref = key_ref.split('#/definitions/').join
+        schema_properties += resolved_schema.fetch("#{ref}").properties.keys
+      # else use conventional way
+      elsif resolved_schema.fetch("#{ref}").properties.values[0].keys.include?('$ref')
+        # gets the keys from deeper level $ref path
+        key_ref = resolved_schema.fetch("#{ref}").properties.values[0].values[0]
+        # turns the $ref path into a specfic $ref
+        ref = key_ref.split('#/definitions/').join
+        # adds the keys from deeper level schema
+        schema_properties += resolved_schema.fetch("#{ref}").properties.keys
       end
     end
-    # Making sure all the properties listed in Swagger definition
-    # are present in the result body
-    (schema_properties & result_keys).sort == schema_properties.sort
+    return schema_properties
   end
 end


### PR DESCRIPTION
ResponseValidator still searches for ref keys in deeper levels of the
definition but now it accounts for refs that make up the elements
of another key with type array. IF this occurs, the tests now uses that
items property to get the ref and obtain the keys for that ref. This will
help in testing the result body to make sure it has all of the keys.