### PR TITLE
Changing from using '.click' to .trigger('click')

### DIFF
--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -150,7 +150,7 @@ feature 'Facet Navigation', js: true do
     ['Type_of_Work', 'Creator', 'Subject', 'Language', 'Publisher', 'Academic_Status'].shuffle.each do |facet_name|
       current_logger.info(context: "Processing Facet: #{facet_name}")
       expect(page).not_to have_css("ul.facets #collapse_#{facet_name}.in")
-      find("ul.facets a[data-target=\"#collapse_#{facet_name}\"]").click
+      find("ul.facets a[data-target=\"#collapse_#{facet_name}\"]").trigger('click')
       expect(page).to have_css("ul.facets #collapse_#{facet_name}.in .slide-list")
     end
   end


### PR DESCRIPTION
Using '.click' sometimes throws this message:

"Firing a click at co-ordinates [190, 780.5] failed. Poltergeist
detected another element with CSS selector
It may be overlapping the element you are trying to interact with.
If you don't care about overlapping elements,
try using node.trigger('click')."

Based on the error message I'm switching to using ".trigger('click')"