### PR TITLE
Updating helper to support tlsv1.2

### DIFF
--- a/spec/webRenovation/webRenovation_spec_helper.rb
+++ b/spec/webRenovation/webRenovation_spec_helper.rb
@@ -9,3 +9,12 @@ end
 Dir.glob(File.expand_path('../utilities/**/*.rb', __FILE__)).each do |filename|
   require filename
 end
+
+Capybara.register_driver :poltergeist do |app|
+  options = {
+       phantomjs_options: [
+         '--ssl-protocol=tlsv1.2'
+       ]
+     }
+  Capybara::Poltergeist::Driver.new(app, options)
+end


### PR DESCRIPTION
I'm updating the spec config to support TLSv1.2. Without this config
phantomjs returns an error even when the site supports tlsv[0,1,2].

```console
Request to 'https://theta.library.nd.edu/' failed to reach server,
check DNS and/or server status
```