### PR TITLE
Spec for usurper_content API

### DIFF
--- a/spec/usurperContent/integration/int_usurperContent_spec.rb
+++ b/spec/usurperContent/integration/int_usurperContent_spec.rb
@@ -1,0 +1,13 @@
+#frozen_string_literal: true
+require 'usurperContent/usurperContent_spec_helper'
+
+feature 'API tests for Usurper Content API' do
+  SwaggerHandler.operations(for_file_path: __FILE__).each do |operation|
+    scenario "calls #{operation.verb} #{operation.path}" do
+      schema = RequestBuilder.new(current_logger, operation)
+      result = schema.send_via_operation_verb
+      current_response = ResponseValidator.new(operation, result)
+      expect(current_response).to be_valid_response
+    end
+  end
+end

--- a/spec/usurperContent/usurperContent_config.yml
+++ b/spec/usurperContent/usurperContent_config.yml
@@ -1,0 +1,3 @@
+dev: jello
+pprd: jello
+prod: jello

--- a/spec/usurperContent/usurperContent_repo_config.yml
+++ b/spec/usurperContent/usurperContent_repo_config.yml
@@ -1,0 +1,1 @@
+repo_url: https://github.com/ndlib/usurper_content

--- a/spec/usurperContent/usurperContent_spec_helper.rb
+++ b/spec/usurperContent/usurperContent_spec_helper.rb
@@ -1,0 +1,2 @@
+#frozen_string_literal: true
+require 'spec_helper'


### PR DESCRIPTION
NOTE: This spec will fail because SwaggerHandler is not equipped to handle the format of swagger currently being [used](https://github.com/ndlib/usurper_content/blob/master/definitions/swagger.yml)

I will be following up this PR by another one with enhancements to the SwaggerHandler