### PR TITLE
Enhancement for SwaggerHandler to read AWS generated swagger defs 

### DIFF
--- a/spec/spec_support/swagger_handler.rb
+++ b/spec/spec_support/swagger_handler.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # This class provides a mechanism to load swagger definition given a project repository
-# It leverages methods exposed by the gem 'swagger-rb'
-#   https://github.com/swagger-rb/swagger-rb
+# It leverages methods exposed by the gem 'swagger-parser'
+#   https://github.com/alexpjohnson/swagger-parser
 class SwaggerHandler
   def self.operations(for_file_path:, config: ENV)
     @registry ||= {}


### PR DESCRIPTION
We're trying to use the same swagger definition for all 'DevOps' activities. ([Here's](https://github.com/ndlib/usurper_content/blob/master/definitions/swagger.yml) a sample)
This enhancement makes the SwaggerHandler run a deep search into a yaml file generated by AWS. 

After I finished up this commit, I came across a [DeepFetch method](https://github.com/intridea/hashie#deepfetch) from Hashie gem which could perhaps do something similar. Any thoughts if I should pursue this as a better solution?
