### PR TITLE
Handling LoadError

### DIFF
--- a/spec/spec_support/json_output_formatter.rb
+++ b/spec/spec_support/json_output_formatter.rb
@@ -9,9 +9,11 @@ class JsonOutputFormatter < RSpec::Core::Formatters::JsonFormatter
   RSpec::Core::Formatters.register self
 
   def close(notification)
-    @output_hash[:runID] ||= "#{RunIdentifier.get}"
+    if @output_hash.fetch(:messages).find{ |e| /31mLoadError/ =~ e }.nil?
+      @output_hash[:runID] ||= "#{RunIdentifier.get}"
+      report_json_result
+    end
     output.write JSON.pretty_generate(@output_hash)
-    report_json_result
   end
 
   def report_json_result


### PR DESCRIPTION
This change handles file loading errors in cases of running tests
against deleted/misspelt spec file locations.
Otherwise the spec proceeds to run injecting runID in @output_hash
variable which isn't initialized yet, and gives a NameError
```console
NameError: uninitialized constant JsonOutputFormatter::RunIdentifier
```