### PR TITLE
Handling KeyError with @output_hash

### DIFF
--- a/spec/spec_support/json_output_formatter.rb
+++ b/spec/spec_support/json_output_formatter.rb
@@ -9,7 +9,7 @@ class JsonOutputFormatter < RSpec::Core::Formatters::JsonFormatter
   RSpec::Core::Formatters.register self
 
   def close(notification)
-    if @output_hash.fetch(:messages).find{ |e| /31mLoadError/ =~ e }.nil?
+    if @output_hash.fetch(:messages, []).find{ |e| /31mLoadError/ =~ e }.nil?
       @output_hash[:runID] ||= "#{RunIdentifier.get}"
       report_json_result
     end


### PR DESCRIPTION
@output_hash doesn't hold the :messages key when we run a test that
passes. This results in a KeyError exception:
```console
KeyError Exception: key not found: :messages
```
I'm using a default value of empty array with the Hash#fetch to handle this error.