### PR TITLE
Mandating assertion for version number in usurper tests

### DIFF
--- a/spec/spec_support/test_runtime.rb
+++ b/spec/spec_support/test_runtime.rb
@@ -85,6 +85,18 @@ module InitializeExample
     Capybara.current_driver = @capybara_driver_name
     Capybara.javascript_driver = @capybara_driver_name
   end
+
+  # Checks for existence of VERSION_NUMBER in ENV config, and exits if it's not found
+  # NOTE: This method is ONLY being called from application specific spec helpers for
+  # those applications where asserting for version numbers of is required
+  # Example: spec/usurper/usurper_spec_helper.rb
+  def self.require_version_number
+    if ENV['VERSION_NUMBER'].nil?
+      ExampleLogging.current_logger.error(context: "VERSION_NUMBER not found in ENV config")
+      ExampleLogging.current_logger.error(context: "Provide VERSION_NUMBER of application being tested")
+      exit!
+    end
+  end
 end
 
 module ErrorReporter

--- a/spec/usurper/pages/base_page.rb
+++ b/spec/usurper/pages/base_page.rb
@@ -11,7 +11,8 @@ module Usurper
       def on_page?
         status_response_ok? &&
           valid_header? &&
-          valid_footer?
+          valid_footer? &&
+          valid_version?
       end
 
       def status_response_ok?
@@ -82,6 +83,18 @@ module Usurper
         within('#chat') do
           find('a.chat-button').visible?
         end
+      end
+
+      def valid_version?
+        # I could have done this implementation with find_by_id("nd-version"),
+        # but that approach does not let me assert on the version number in the 'content' attribute
+        # of meta tags. That's because Capybara does not support :content option in it's have_selector? method
+        # So I'm using string interpolation to assert on the entire selector
+        # Reference: https://stackoverflow.com/questions/12801463/capture-and-assert-meta-tags-in-rspec
+        # Reference: https://joanswork.com/rspec-test-specific-meta-tag-content/
+        expected_version = ENV['VERSION_NUMBER']
+        version_meta_tag = "meta[id=\"nd-version\"][content=\"#{expected_version}\"]"
+        find(version_meta_tag, visible: false)
       end
     end
   end

--- a/spec/usurper/usurper_config.yml
+++ b/spec/usurper/usurper_config.yml
@@ -1,2 +1,2 @@
 test: https://alpha.library.nd.edu/
-prod: https://beta.library.nd.edu/
+prod: https://library.nd.edu/

--- a/spec/usurper/usurper_spec_helper.rb
+++ b/spec/usurper/usurper_spec_helper.rb
@@ -18,3 +18,9 @@ Capybara.register_driver :poltergeist do |app|
      }
   Capybara::Poltergeist::Driver.new(app, options)
 end
+
+RSpec.configure do |config|
+  config.before(:example) do
+    InitializeExample.require_version_number
+  end
+end


### PR DESCRIPTION
* Updated usurper config
* Adds an assertion for release number in BasePage class of usurper
* Adds a method in InitializeExample module to require VERSION_NUMBER as an ENV variable