### PR TITLE
Updates cas_login.rb to (semi)fix login bug

### DIFF
--- a/spec/spec_support/cas_login.rb
+++ b/spec/spec_support/cas_login.rb
@@ -68,9 +68,12 @@ class LoginPage
     page.has_selector?("input[name=passcode]")
     fill_in('passcode', with: passCode)
     page.has_selector?('.form-signin [name=submit]')
-    find('.form-signin [name=submit]').trigger('click')
+    # keeps clicking until the cas login page is gone (TEMP FIX)
+    loop do
+      find('.form-signin [name=submit]').trigger('click')
+      break if page.has_no_selector?('.form-signin [name=submit]')
+      # waits for it to leave the login page
+    end
     current_logger.info(context: "Logging in user: #{userName}")
-    # waits for it to leave the login page
-    page.has_no_selector?('.form-signin [name=submit]')
   end
 end


### PR DESCRIPTION
**This is a temporary fix**
For some reason, when logging into CAS, the trigger('click') on the login
button of the final step is not firing.  This commit alters this final step
by using a do-until loop that clicks the login button until the CAS login
button (and therefore the page) is no longer visible. Thus, this also utilizes the maleficent
sleep injector to wait in between each click as that may be part of the issue. In doing so, it ensures that the login button will be clicked and keep this bug from causing tests to fail.