### PR TITLE
Adding sleep statement to allow homepage load

### DIFF
--- a/spec/usurper/functional/func_usurper_spec.rb
+++ b/spec/usurper/functional/func_usurper_spec.rb
@@ -253,6 +253,7 @@ feature 'User Navigation', js: true do
           find('.map')
         end
         find_link('Home').trigger('click')
+        sleep(2)
         within('.uNavigation') do
           find_by_id('libraries').trigger('click')
         end


### PR DESCRIPTION
This is a quick fix to make ensure the homepage loads before next iteration begins.