### PR TITLE
The version of bunyan capybara used to use the path parameter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ GEM
     aws-sdk-resources (2.10.3)
       aws-sdk-core (= 2.10.3)
     aws-sigv4 (1.0.0)
-    bunyan_capybara (0.1.3)
+    bunyan_capybara (0.1.4)
       capybara (~> 2.13)
     byebug (9.0.6)
     capistrano (3.8.2)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,9 +21,10 @@ Dir.glob(File.expand_path('../spec_support/**/*.rb', __FILE__)).each { |filename
 
 Capybara.run_server = false
 
+spec_path = File.expand_path('../', __FILE__)
 # Keep only the screenshots generated from the last failing test suite
 Capybara::Screenshot.prune_strategy = :keep_last_run
-Bunyan.instantiate_all_loggers!(config: ENV)
+Bunyan.instantiate_all_loggers!(config: ENV, path: spec_path)
 
 # Gives access to the capybara methods
 RSpec.configure do |config|


### PR DESCRIPTION
The Bunyan module now has an path: parameter for its instantiate_all_loggers
method. This parameter is used in the spec_helper to give the location of the
spec folder to the module so it can properly create/update the bunyan_logs folder
and the *.log files. the spec_path variable is used to hold the path structure
to the said spec folder.