### PR TITLE
Adding new scenario for 'ORCID settings'

### DIFF
--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -482,3 +482,26 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     login_page.checkLoginPage
   end
 end
+
+feature 'Logged in user changing ORCID settings:', js: true do
+  let(:login_page) { LoginPage.new(current_logger, account_details_updated: false) }
+  scenario "Go to ORCID.org home page", :validates_login do
+    visit '/'
+    click_on('Log In')
+    login_page.completeLogin
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
+    expect(logged_in_home_page).to be_on_page
+    logged_in_home_page.openActionsDrawer
+    click_on("My Profile")
+    account_details_page = Curate::Pages::AccountDetailsPage.new
+    expect(account_details_page).to be_on_page
+    find_link('ORCID Settings').trigger('click')
+    sleep(1)
+    orcid_settings_page = Curate::Pages::OrcidSettingsPage.new
+    expect(orcid_settings_page).to be_on_page
+    find_link('Create or Connect your ORCID iD').trigger('click')
+    sleep(1)
+    orcid_home_page = Curate::Pages::OrcidHomePage.new
+    expect(orcid_home_page).to be_on_page
+  end
+end

--- a/spec/curate/pages/orcid_home_page.rb
+++ b/spec/curate/pages/orcid_home_page.rb
@@ -8,11 +8,12 @@ module Curate
       def on_page?
         on_valid_url? &&
           status_response_ok? &&
-          valid_page_content?
+          valid_page_content? &&
+          valid_uri_parameters?
       end
 
       def on_valid_url?
-        current_url.include?('orcid.org')
+        Capybara.current_host.include?('orcid.org')
       end
 
       def status_response_ok?
@@ -23,6 +24,16 @@ module Curate
         page.has_content?("ORCID")
         page.has_selector?(:link_or_button, "Register now")
         page.has_selector?(:link_or_button, "Sign into ORCID")
+      end
+
+      def valid_uri_parameters?
+        # Since we're not testing the full use case of redirecting back after ORCID sign in,
+        # these assertions provide a certain degree of validation that the site fires a correct redirect URL
+        hostname_to_redirect = URI.parse(Capybara.app_host).host
+        redirect_url_to_check = 'redirect_uri=https%3A%2F%2F' + hostname_to_redirect + '%2Forcid%2Fcreate_orcid'
+        current_url.include?(redirect_url_to_check)
+        current_url.include?('response_type=code')
+        current_url.include?('scope=%2Fread-limited+%2Factivities%2Fupdate')
       end
     end
   end

--- a/spec/curate/pages/orcid_home_page.rb
+++ b/spec/curate/pages/orcid_home_page.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Curate
   module Pages
-    class AccountDetailsPage
+    class OrcidHomePage
       include Capybara::DSL
       include CapybaraErrorIntel::DSL
 
@@ -12,7 +12,7 @@ module Curate
       end
 
       def on_valid_url?
-        current_url == File.join(Capybara.app_host, 'users/edit')
+        current_url.include?('orcid.org')
       end
 
       def status_response_ok?
@@ -20,9 +20,9 @@ module Curate
       end
 
       def valid_page_content?
-        has_content?("Account Details")
-        has_selector?(:link_or_button, "Update My Account")
-        has_selector?(:link_or_button, "ORCID Settings")
+        page.has_content?("ORCID")
+        page.has_selector?(:link_or_button, "Register now")
+        page.has_selector?(:link_or_button, "Sign into ORCID")
       end
     end
   end

--- a/spec/curate/pages/orcid_settings_page.rb
+++ b/spec/curate/pages/orcid_settings_page.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Curate
   module Pages
-    class AccountDetailsPage
+    class OrcidSettingsPage
       include Capybara::DSL
       include CapybaraErrorIntel::DSL
 
@@ -12,7 +12,7 @@ module Curate
       end
 
       def on_valid_url?
-        current_url == File.join(Capybara.app_host, 'users/edit')
+        current_url == File.join(Capybara.app_host, 'orcid_settings')
       end
 
       def status_response_ok?
@@ -20,9 +20,10 @@ module Curate
       end
 
       def valid_page_content?
-        has_content?("Account Details")
-        has_selector?(:link_or_button, "Update My Account")
-        has_selector?(:link_or_button, "ORCID Settings")
+        page.has_content?("ORCID Settings")
+        page.has_selector?(:link_or_button, "ORCID Settings")
+        page.has_selector?(:link_or_button, "Open Researcher and Contributor ID (ORCID)")
+        page.has_selector?(:link_or_button, "Create or Connect your ORCID iD")
       end
     end
   end


### PR DESCRIPTION
This scenario logs in with a test user account whose account details have not been updated and checks if the user can get to the ORCID sign up page. 

I'm not testing further scenarios due to following restrictions:
* The ORCID sign up page has a reCAPTCHA that's making it very hard to register as a bot
* Once an account's ORCID id has been created I cannot recreate another one for it. I have only 5 test accounts that can login into CAS, which will get exhausted in few iterations of testing.
