### PR TITLE
Fixing reference to ExampleVariableExtractor

### DIFF
--- a/spec/spec_support/swagger_handler.rb
+++ b/spec/spec_support/swagger_handler.rb
@@ -5,7 +5,7 @@
 class SwaggerHandler
   def self.operations(for_file_path:, config: ENV)
     @registry ||= {}
-    example_variable = ExampleVariableExtractor.call(path: for_file_path, config: config)
+    example_variable = BunyanVariableExtractor.call(path: for_file_path, config: config)
     @registry[example_variable] ||= new(example_variable: example_variable, config: config)
     @registry[example_variable].operations
   end


### PR DESCRIPTION
After we extracted the logger and variable extractor into
a separate gem (https://github.com/ndlib/bunyan_capybara), we did
not refactor the older references to ExampleVariableExtractor.
This causes the swagger handler to fail:
```error
uninitialized constant SwaggerHandler::ExampleVariableExtractor
```

This commit corrects the reference to BunyanVariableExtractor