### PR TITLE
Mh bunyan

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,5 +26,5 @@ group :testcontroller do
   gem 'contentful'
   gem 'google_drive'
   gem 'contentful-management'
-  gem 'bunyan_capybara'
+  gem 'bunyan_capybara', path: '~/git/bunyan_capybara'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -26,5 +26,5 @@ group :testcontroller do
   gem 'contentful'
   gem 'google_drive'
   gem 'contentful-management'
-  gem 'bunyan_capybara', path: '~/git/bunyan_capybara'
+  gem 'bunyan_capybara'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+PATH
+  remote: ../bunyan_capybara
+  specs:
+    bunyan_capybara (0.1.5)
+      capybara (~> 2.13)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -25,8 +31,6 @@ GEM
     aws-sdk-resources (2.10.3)
       aws-sdk-core (= 2.10.3)
     aws-sigv4 (1.0.0)
-    bunyan_capybara (0.1.4)
-      capybara (~> 2.13)
     byebug (9.0.6)
     capistrano (3.8.2)
       airbrussh (>= 1.0.0)
@@ -214,7 +218,7 @@ DEPENDENCIES
   activesupport
   airborne
   aws-sdk
-  bunyan_capybara
+  bunyan_capybara!
   byebug
   capistrano
   capistrano-bundler

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,3 @@
-PATH
-  remote: ../bunyan_capybara
-  specs:
-    bunyan_capybara (0.1.5)
-      capybara (~> 2.13)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -31,6 +25,8 @@ GEM
     aws-sdk-resources (2.10.3)
       aws-sdk-core (= 2.10.3)
     aws-sigv4 (1.0.0)
+    bunyan_capybara (0.2.5)
+      capybara (~> 2.13)
     byebug (9.0.6)
     capistrano (3.8.2)
       airbrussh (>= 1.0.0)
@@ -218,7 +214,7 @@ DEPENDENCIES
   activesupport
   airborne
   aws-sdk
-  bunyan_capybara!
+  bunyan_capybara
   byebug
   capistrano
   capistrano-bundler

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,7 +42,6 @@ RSpec.configure do |config|
   config.before(:suite) do |rspec_suite|
     @current_logger = Bunyan.start(example: rspec_suite, config: ENV, test_handler: self)
     Bunyan.current_logger = @current_logger
-    require 'byebug'; debugger
     RunIdentifier.set
     CloudwatchEventHandler.set_aws_config
     new_save_path = ScreenshotsManager.get_screenshots_save_path

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,11 +39,16 @@ RSpec.configure do |config|
   config.order = :random
   Kernel.srand config.seed
 
-  config.before(:suite) do
+  config.before(:suite) do |rspec_suite|
+    @current_logger = Bunyan.start(example: rspec_suite, config: ENV, test_handler: self)
+    Bunyan.current_logger = @current_logger
+    require 'byebug'; debugger
     RunIdentifier.set
     CloudwatchEventHandler.set_aws_config
     new_save_path = ScreenshotsManager.get_screenshots_save_path
     Capybara.save_path = new_save_path
+    @current_logger.stop()
+    Bunyan.reset_current_logger!
   end
 
   config.before(:example) do |rspec_example|

--- a/spec/spec_support/cloudwatch_event_handler.rb
+++ b/spec/spec_support/cloudwatch_event_handler.rb
@@ -3,12 +3,16 @@ require 'aws-sdk'
 
 module CloudwatchEventHandler
   def self.set_aws_config
-    return true if ENV.fetch('SKIP_CLOUDWATCH', false)
+    if ENV.fetch('SKIP_CLOUDWATCH', false)
+      Bunyan.current_logger.debug(context:'Cloudwatch skipped')
+      return true
+    end
     target_aws_account = 'testlibnd'
     user_home_dir = File.expand_path('~')
     aws_env_config_file = YAML.load_file(File.join("#{user_home_dir}", 'test_data/QA/aws_config.yaml'))
     Aws.config.update({region: aws_env_config_file.fetch("#{target_aws_account}").fetch("default_region_name")})
     Aws.config.update({credentials: Aws::Credentials.new(aws_env_config_file.fetch("#{target_aws_account}").fetch("aws_access_key_id"), aws_env_config_file.fetch("#{target_aws_account}").fetch("aws_secret_access_key"))})
+    Bunyan.current_logger.debug(context: 'AWS Cloudwatch Config set')
   end
 
   def self.report_json_result(output_hash:)

--- a/spec/spec_support/test_runtime.rb
+++ b/spec/spec_support/test_runtime.rb
@@ -5,8 +5,8 @@ module RunIdentifier
   # * Provides getter and setter methods to
   # create a unique ID for identifying the test run
   def self.set
-    Bunyan.current_logger.info(context: 'YOOOOOOOOOOOOOOOOOOOO')
     @run_identifier = DateTime.now.strftime("%Y-%m-%dT%H:%M:%S.%L-05:00")
+    Bunyan.current_logger.debug(context: 'RunIdentifier set')
   end
 
   def self.get
@@ -36,6 +36,7 @@ module ScreenshotsManager
     FileUtils.mkdir RunIdentifier.get
     Dir.chdir(current_working_directory) # Return to current directory so screenshots are in the right place
     File.join(screenshots_root, RunIdentifier.get)
+    Bunyan.current_logger.debug(context: 'Screenshots Save Path found')
   end
 end
 

--- a/spec/spec_support/test_runtime.rb
+++ b/spec/spec_support/test_runtime.rb
@@ -5,6 +5,7 @@ module RunIdentifier
   # * Provides getter and setter methods to
   # create a unique ID for identifying the test run
   def self.set
+    Bunyan.current_logger.info(context: 'YOOOOOOOOOOOOOOOOOOOO')
     @run_identifier = DateTime.now.strftime("%Y-%m-%dT%H:%M:%S.%L-05:00")
   end
 


### PR DESCRIPTION
* alters spec_helper to allow for bunyan_capybara debug logging to be used before the suite starts so if errors occur before examples there is a better indication where the failure occured
* updates the Gemfile to use the new version of bunyan_capybara
* places current_logger.debug statements for the modules used in the before(:suite) block (i.e. RunIdentifier, CloudwatchEventHandler) in case of pre_suite failures
