### PR TITLE
new gemfile.lock for new version of bunyan_capybara

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ GEM
     aws-sdk-resources (2.10.3)
       aws-sdk-core (= 2.10.3)
     aws-sigv4 (1.0.0)
-    bunyan_capybara (0.1.5)
+    bunyan_capybara (0.2.6)
       capybara (~> 2.13)
     byebug (9.0.6)
     capistrano (3.8.2)
@@ -214,7 +214,7 @@ DEPENDENCIES
   activesupport
   airborne
   aws-sdk
-  bunyan_capybara (= 0.1.5)
+  bunyan_capybara
   byebug
   capistrano
   capistrano-bundler


### PR DESCRIPTION
bunyan_capybara has been updated to solve https://github.com/ndlib/bunyan_capybara/issues/4 using Harsh's guidelines for the RegExp method post_match as seen in the issue.