### PR TITLE
Adjusting tests for library website release  r20171103

### DIFF
--- a/spec/usurper/functional/func_usurper_spec.rb
+++ b/spec/usurper/functional/func_usurper_spec.rb
@@ -166,7 +166,7 @@ feature 'User Browsing', js: true do
     end
     find_button('Search').trigger('click')
     sleep(2)
-    expect(current_url).to eq('https://curate.nd.edu/catalog?utf8=%E2%9C%93&amp;search_field=all_fields&amp;q=')
+    expect(current_url).to match(/^https:\/\/curate.nd.edu\/catalog./)
   end
 
   scenario 'Search using Library Website from HomePage' do
@@ -177,7 +177,7 @@ feature 'User Browsing', js: true do
     end
     find_button('Search').trigger('click')
     sleep(2)
-    expect(current_url).to eq('https://search.nd.edu/search/?client=lib_site_srch&site=library;q=')
+    expect(current_url).to match(/^https:\/\/search.nd.edu\/search\/./)
   end
 end
 

--- a/spec/usurper/functional/func_usurper_spec.rb
+++ b/spec/usurper/functional/func_usurper_spec.rb
@@ -247,7 +247,9 @@ feature 'User Navigation', js: true do
     # use the strings from the hash in order to make assertions
     text_and_href_list.each do |pair|
       if pair[1].include?(Capybara.app_host)
-        click_on(pair[0])
+        within('#librariesNav') do
+          click_on(pair[0])
+        end
         sleep(2)
         within('.building') do
           find('.map')

--- a/spec/usurper/pages/base_page.rb
+++ b/spec/usurper/pages/base_page.rb
@@ -34,7 +34,7 @@ module Usurper
           find_by_id('about').trigger('click')
           menu_drawer_has_content?
           # need to close 'About' tab or issues randomly pop up
-          find_by_id('about').trigger('click')
+          find('a', id: 'about').trigger('click')
           if @loggedin
             find('.m', text: 'MY ACCOUNT')
           else

--- a/spec/usurper/pages/courses_page.rb
+++ b/spec/usurper/pages/courses_page.rb
@@ -19,7 +19,7 @@ module Usurper
       end
 
       def on_valid_url?
-        current_url == File.join(Capybara.app_host, "courses")
+        current_url == File.join(Capybara.app_host, "courses") || current_url == File.join(Capybara.app_host, "courses#")
       end
     end
   end

--- a/spec/usurper/pages/home_page.rb
+++ b/spec/usurper/pages/home_page.rb
@@ -16,7 +16,7 @@ module Usurper
       end
 
       def on_valid_url?
-        current_url == Capybara.app_host || current_url == (Capybara.app_host + "/")
+        current_url == Capybara.app_host || current_url == (Capybara.app_host + "/") || current_url == (Capybara.app_host + "#")
       end
 
       # These links are only visible on the home page, and not on any other pages of the site

--- a/spec/usurper/pages/hours_page.rb
+++ b/spec/usurper/pages/hours_page.rb
@@ -25,7 +25,7 @@ module Usurper
       end
 
       def correct_url?
-        current_url == File.join(Capybara.app_host, "hours")
+        current_url == File.join(Capybara.app_host, "hours") || current_url == File.join(Capybara.app_host, "hours#")
       end
     end
   end

--- a/spec/usurper/pages/items_page.rb
+++ b/spec/usurper/pages/items_page.rb
@@ -21,7 +21,7 @@ module Usurper
       end
 
       def on_valid_url?
-        current_url == File.join(Capybara.app_host, "items-requests")
+        current_url == File.join(Capybara.app_host, "items-requests") || current_url == File.join(Capybara.app_host, "items-requests#")
       end
 
     end

--- a/spec/usurper/pages/library_jobs_page.rb
+++ b/spec/usurper/pages/library_jobs_page.rb
@@ -18,7 +18,7 @@ module Usurper
       end
 
       def on_valid_url?
-        current_url == File.join(Capybara.app_host, "employment/")
+        current_url == File.join(Capybara.app_host, "employment/") || current_url == File.join(Capybara.app_host, "employment/#")
       end
     end
   end

--- a/spec/usurper/pages/reserve_a_room_page_services_tab.rb
+++ b/spec/usurper/pages/reserve_a_room_page_services_tab.rb
@@ -18,7 +18,7 @@ module Usurper
       end
 
       def on_valid_url?
-        current_url == File.join(Capybara.app_host, 'room-reservations')
+        current_url == File.join(Capybara.app_host, 'room-reservations') || current_url == File.join(Capybara.app_host, 'room-reservations#')
       end
     end
   end

--- a/spec/usurper/pages/search_page.rb
+++ b/spec/usurper/pages/search_page.rb
@@ -5,8 +5,8 @@ module Usurper
       include CapybaraErrorIntel::DSL
 
       def initialize
-        @one_search_url = 'http://onesearch.library.nd.edu/primo_library/libweb/action/dlSearch.do?bulkSize=10&dym=true&highlight=true&indx=1&institution=NDU&mode=Basic&onCampus=false&pcAvailabiltyMode=true&query=any%2Ccontains%2C&search_scope=malc_blended&tab=onesearch&vid=NDU&displayField=title&displayField=creator'
-        @nd_catlog_search_url = 'http://onesearch.library.nd.edu/primo_library/libweb/action/dlSearch.do?bulkSize=10&dym=true&highlight=true&indx=1&institution=NDU&mode=Basic&onCampus=false&pcAvailabiltyMode=true&query=any%2Ccontains%2C&search_scope=nd_campus&tab=nd_campus&vid=NDU&displayField=title&displayField=creator'
+        @one_search_url = 'http://onesearch.library.nd.edu/primo_library/libweb/action/search.do?fn=search&ct=search&initialSearch=true&mode=Basic&tab=onesearch&indx=1&dum=true&srt=rank&vid=NDU&frbg=&tb=t&vl%28freeText0%29=&scp.scps=scope%3A%28hathi_pub%29%2Cscope%3A%28ndulawrestricted%29%2Cscope%3A%28dtlrestricted%29%2Cscope%3A%28NDU%29%2Cscope%3A%28NDLAW%29%2Cscope%3A%28ndu_digitool%29'
+        @nd_catlog_search_url = 'http://onesearch.library.nd.edu/primo_library/libweb/action/search.do?fn=search&ct=search&initialSearch=true&mode=Basic&tab=nd_campus&indx=1&dum=true&srt=rank&vid=NDU&frbg=&tb=t&vl%28freeText0%29=&scp.scps=scope%3A%28hathi_pub%29%2Cscope%3A%28ndulawrestricted%29%2Cscope%3A%28dtlrestricted%29%2Cscope%3A%28NDU%29%2Cscope%3A%28NDLAW%29%2Cscope%3A%28ndu_digitool%29'
       end
 
       def on_page?

--- a/spec/usurper/pages/technology_lending.rb
+++ b/spec/usurper/pages/technology_lending.rb
@@ -11,7 +11,7 @@ module Usurper
       end
 
       def on_valid_url?
-        current_url == File.join(Capybara.app_host, 'technology-lending')
+        current_url == File.join(Capybara.app_host, 'technology-lending') || current_url == File.join(Capybara.app_host, 'technology-lending#')
       end
       def correct_content?
         within('.container-fluid.content-area') do

--- a/spec/usurper/pages/thesis_and_dissertation_camps.rb
+++ b/spec/usurper/pages/thesis_and_dissertation_camps.rb
@@ -12,7 +12,7 @@ module Usurper
       end
 
       def on_valid_url?
-        current_url == File.join(Capybara.app_host,  'thesis-dissertation-camps')
+        current_url == File.join(Capybara.app_host,  'thesis-dissertation-camps') || current_url == File.join(Capybara.app_host,  'thesis-dissertation-camps#')
       end
     end
   end

--- a/spec/usurper/usurper_config.yml
+++ b/spec/usurper/usurper_config.yml
@@ -1,2 +1,3 @@
 test: https://alpha.library.nd.edu/
+prep: https://beta.library.nd.edu/
 prod: https://library.nd.edu/


### PR DESCRIPTION
* avoids ambiguous matches by specifying element types and using 'within' blocks
* Adds beta site as a 'prep' URL to the config
* Updates onesearch URLs to the current values
* Changes absolute URLs to regexps
* Accommodates assertions for '#' in URLs