### PR TITLE
Updates contentful handler to use the new USE_CONTENTFUL_SPACE toggle

### DIFF
--- a/spec/contentful/contentful_spec_helper.rb
+++ b/spec/contentful/contentful_spec_helper.rb
@@ -11,4 +11,7 @@ RSpec.configure do |config|
   config.before(:example) do
     InitializeExample.require_release_number
   end
+  config.before(:example) do
+    InitializeExample.require_contentful_space
+  end
 end

--- a/spec/spec_support/contentful_handler.rb
+++ b/spec/spec_support/contentful_handler.rb
@@ -60,9 +60,8 @@ class ContentfulHandler
 
     def read_contentful_tokens
       cf_key_file = YAML.load_file(File.join(ENV.fetch('HOME'), 'test_data/QA/cf_api_key.yml'))
-      # Change the qa_key to fetch 'prep' when you want to test in non-production contentful space
-      # TODO: https://github.com/ndlib/QA_tests/issues/234 
-      qa_key = cf_key_file.fetch('prod')
+      contentful_space = ENV['USE_CONTENTFUL_SPACE']
+      qa_key = cf_key_file.fetch(contentful_space)
       @space_id = qa_key.fetch('space_id')
       @cdn_token = qa_key.fetch('cdn_token')
       @preview_token = qa_key.fetch('preview_token')

--- a/spec/spec_support/test_runtime.rb
+++ b/spec/spec_support/test_runtime.rb
@@ -129,6 +129,21 @@ module InitializeExample
       exit!
     end
   end
+
+  # Checks for existence of USE_CONTENTFUL_SPACE in ENV config, checks if the proper values are assigned to it, and exits if it's not found or if incorrect values are assigned
+  # NOTE: This method is ONLY being called from application specific spec helpers for
+  # those tests where asserting for release numbers of is required
+  # Example: spec/contentful/contentful_spec_helper.rb
+  def self.require_contentful_space
+    if ENV['USE_CONTENTFUL_SPACE'].nil?
+      Bunyan.current_logger.error(context: "USE_CONTENTFUL_SPACE not found in ENV config")
+      Bunyan.current_logger.error(context: "Provide USE_CONTENTFUL_SPACE to designate desired Contentful space (prod or prep)")
+      exit!
+    elsif ENV['USE_CONTENTFUL_SPACE'] != 'prod' && ENV['USE_CONTENTFUL_SPACE'] != 'prep'
+      Bunyan.current_logger.error(context: "Only options for USE_CONTENTFUL_SPACE are prod or prep")
+      exit!
+    end
+  end
 end
 
 module ErrorReporter

--- a/spec/spec_support/test_runtime.rb
+++ b/spec/spec_support/test_runtime.rb
@@ -132,7 +132,7 @@ module InitializeExample
 
   # Checks for existence of USE_CONTENTFUL_SPACE in ENV config, checks if the proper values are assigned to it, and exits if it's not found or if incorrect values are assigned
   # NOTE: This method is ONLY being called from application specific spec helpers for
-  # those tests where asserting for release numbers of is required
+  # those tests where assertion of contentful space of is required
   # Example: spec/contentful/contentful_spec_helper.rb
   def self.require_contentful_space
     if ENV['USE_CONTENTFUL_SPACE'].nil?


### PR DESCRIPTION
* USE_CONTENTFUL_SPACE toggle allows user to specify whether to use prod or prep space
* in test_runtime, adds require_contentful_space method to be referenced in contentful_spec_helper
* require_contentful_space method checks if user used USE_CONTENTFUL_SPACE toggle and if the user provided correct values for it
* Changes read_contentful_tokens method in contentful_handler to use the user specified contentful space to get qa_key