### PR TITLE
Updating to allow ./bin/run_tests to work

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -1,7 +1,9 @@
 #!/usr/bin/env ruby -wU
 # frozen_string_literal: true
-
-require File.expand_path('../../spec/spec_support/example_logging_constants', __FILE__)
+unless defined?(Bunyan)
+  gem 'bunyan_capybara'
+  require 'bunyan_capybara/bunyan_constants'
+end
 
 # *****************************************************************************
 #


### PR DESCRIPTION
I was attempting to run the tests locally, and encountered errors in
in the command `./bin/run_tests -h`. Below is the error message:

```console
`require': cannot load such file -- ./QA_tests/spec/spec_support/example_logging_constants (LoadError)
```

I believe this is the result of refactoring to using the Bunyan gem. The
change fixes the error and now `./bin/run_tests -h` outputs the help
message.