### PR TITLE
Changes lib_cal_id from hard code to dynamic

### DIFF
--- a/spec/contentful/integration/int_contentful_spec.rb
+++ b/spec/contentful/integration/int_contentful_spec.rb
@@ -23,10 +23,8 @@ feature 'Tests for Contentful entries and webhook integrations' do
   # I am calling /newevent via contentful to make sure the webhooks are firing
   # correctly, and the event is then previewable
   # 'lib_cal_id' is a unique ID that is used to pull data from the libcal system
-  # TODO: Parameterize libcal ID, we should leverage the PathParameterizer::ParameterFinder
-  # class. It probably needs some refactor becuase it's designed to parameterize
-  # endpoints for path and query parameters
-  # Tracking here: https://github.com/ndlib/QA_tests/issues/233
+  # libcal ID is parameterized by leveraging the PathParameterizer::ParameterFinder
+  # class along with the associated find method of ParameterFinder
   scenario "Create and preview an entry of type 'Events'" do
     contentful_params = PathParameterizer::ParameterFinder.new(application_name_under_test: 'contentful')
     lib_cal_id = contentful_params.find(key: 'libCalId').to_s

--- a/spec/contentful/integration/int_contentful_spec.rb
+++ b/spec/contentful/integration/int_contentful_spec.rb
@@ -28,7 +28,9 @@ feature 'Tests for Contentful entries and webhook integrations' do
   # endpoints for path and query parameters
   # Tracking here: https://github.com/ndlib/QA_tests/issues/233
   scenario "Create and preview an entry of type 'Events'" do
-    ContentfulHandler.create(current_logger: current_logger, content_type: 'event', lib_cal_id: '3596276') do |entry|
+    contentful_params = YAML.load_file(ENV['HOME']+"/test_data/QA/parameters/contentful.yml")
+    lib_cal_id = contentful_param['libCalId'][0].values.sample.to_s
+    ContentfulHandler.create(current_logger: current_logger, content_type: 'event', lib_cal_id: lib_cal_id ) do |entry|
       entry.verify_webhooks
       expect(entry).not_to be_published
       # This isn't elegant but necessary in this case, because we want to wait for the

--- a/spec/contentful/integration/int_contentful_spec.rb
+++ b/spec/contentful/integration/int_contentful_spec.rb
@@ -28,8 +28,8 @@ feature 'Tests for Contentful entries and webhook integrations' do
   # endpoints for path and query parameters
   # Tracking here: https://github.com/ndlib/QA_tests/issues/233
   scenario "Create and preview an entry of type 'Events'" do
-    contentful_params = YAML.load_file(ENV['HOME']+"/test_data/QA/parameters/contentful.yml")
-    lib_cal_id = contentful_param['libCalId'][0].values.sample.to_s
+    contentful_params = PathParameterizer::ParameterFinder.new(application_name_under_test: 'contentful')
+    lib_cal_id = contentful_params.find(key: 'libCalId').to_s
     ContentfulHandler.create(current_logger: current_logger, content_type: 'event', lib_cal_id: lib_cal_id ) do |entry|
       entry.verify_webhooks
       expect(entry).not_to be_published


### PR DESCRIPTION
Previously, the value for lib_cal_id, which represents the contentful parameter,
was hardcoded to a set value.  Now, the scenario gets the value for lib_cal_id
from the test_data/QA/parameters/contentful.yml file hen randomly picks the lib_cal_id
from the available options.  This adds flexibility for the values and helps avoid future code changes
if the values from the yml file change.