### PR TITLE
Fixes curate tests failing due to failed network resources

### DIFF
--- a/spec/curate/curate_spec_helper.rb
+++ b/spec/curate/curate_spec_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'spec_helper'
+require File.expand_path('../pages/home_page.rb', __FILE__)
 Dir.glob(File.expand_path('../pages/**/*.rb', __FILE__)).each do |filename|
   require filename
 end

--- a/spec/curate/pages/audio_page.rb
+++ b/spec/curate/pages/audio_page.rb
@@ -3,7 +3,7 @@ module Curate
     class AudioPage
       include Capybara::DSL
       include CapybaraErrorIntel::DSL
-
+      VerifyNetworkTraffic::EXCLUDE_URI_FROM_NETWORK_TRAFFIC_VALIDATION << '/assets/ui-bg_highlight-soft_100_eeeeee_1x100.png'
       def on_page?
           on_valid_url? &&
           status_response_ok? &&

--- a/spec/curate/pages/audio_page.rb
+++ b/spec/curate/pages/audio_page.rb
@@ -3,7 +3,7 @@ module Curate
     class AudioPage
       include Capybara::DSL
       include CapybaraErrorIntel::DSL
-      VerifyNetworkTraffic::EXCLUDE_URI_FROM_NETWORK_TRAFFIC_VALIDATION << '/assets/ui-bg_highlight-soft_100_eeeeee_1x100.png'
+      VerifyNetworkTraffic.exclude_uri_from_network_traffic_validation.push('/assets/ui-bg_highlight-soft_100_eeeeee_1x100.png')
       def on_page?
           on_valid_url? &&
           status_response_ok? &&

--- a/spec/spec_support/test_runtime.rb
+++ b/spec/spec_support/test_runtime.rb
@@ -164,7 +164,10 @@ module VerifyNetworkTraffic
   # leverages network_traffic method of poltergeist driver to verify
   # that all the network calls for static assets and 3rd party support
   # are working on the site
-  EXCLUDE_URI_FROM_NETWORK_TRAFFIC_VALIDATION = []
+  def self.exclude_uri_from_network_traffic_validation
+    @exclude_uri_from_network_traffic_validation ||= []
+  end
+
   def self.report_network_traffic(driver:, test_handler:)
     @driver = driver
     @test_handler = test_handler
@@ -201,10 +204,10 @@ module VerifyNetworkTraffic
           resource_hash = { url: response.url, status_code: response.status }
           non_uri_resources << resource_hash
           Bunyan.current_logger.debug(context: "Verification skipped, Resource isn't of type URI", url: response.url, status_code: response.status)
-        elsif EXCLUDE_URI_FROM_NETWORK_TRAFFIC_VALIDATION.include? URI.parse(response.url).request_uri
+        elsif @exclude_uri_from_network_traffic_validation.include? URI.parse(response.url).request_uri
           resource_hash = { url: response.url, status_code: response.status }
           not_verified_resources << resource_hash
-          Bunyan.current_logger.debug(context: "Verification skipped, resource exists in EXCLUDE_URI_FROM_NETWORK_TRAFFIC_VALIDATION", url: response.url, status_code: response.status)
+          Bunyan.current_logger.debug(context: "Verification skipped, resource exists in @exclude_uri_from_network_traffic_validation", url: response.url, status_code: response.status)
         elsif (400..599).cover? response.status
           resource_hash = { url: response.url, status_code: response.status }
           failed_resources << resource_hash

--- a/spec/spec_support/test_runtime.rb
+++ b/spec/spec_support/test_runtime.rb
@@ -164,6 +164,7 @@ module VerifyNetworkTraffic
   # leverages network_traffic method of poltergeist driver to verify
   # that all the network calls for static assets and 3rd party support
   # are working on the site
+  EXCLUDE_URI_FROM_NETWORK_TRAFFIC_VALIDATION = []
   def self.report_network_traffic(driver:, test_handler:)
     @driver = driver
     @test_handler = test_handler
@@ -185,20 +186,37 @@ module VerifyNetworkTraffic
     Capybara.current_driver == :poltergeist
   end
 
+  # This method slices all the network traffic into 4 categories and validates them:
+  # non_uri_resources: resources that are not URIs (come through due to bugs in Poltergeist)
+  # not_verified_resources: resources that have been requested not to be verified (Assets that may be failing)
+  # failed_resources: resources that should give an error message on certain conditions
   def self.verify_network_traffic(driver:)
     failed_resources = []
+    not_verified_resources = []
+    non_uri_resources = []
+    verification_passed_resources = []
     driver.network_traffic.each do |request|
       request.response_parts.uniq(&:url).each do |response|
-        if (400..599).cover? response.status
+      if ! InitializeExample.valid_url?(response.url)
+          resource_hash = { url: response.url, status_code: response.status }
+          non_uri_resources << resource_hash
+          Bunyan.current_logger.debug(context: "Verification skipped, Resource isn't of type URI", url: response.url, status_code: response.status)
+        elsif EXCLUDE_URI_FROM_NETWORK_TRAFFIC_VALIDATION.include? URI.parse(response.url).request_uri
+          resource_hash = { url: response.url, status_code: response.status }
+          not_verified_resources << resource_hash
+          Bunyan.current_logger.debug(context: "Verification skipped, resource exists in EXCLUDE_URI_FROM_NETWORK_TRAFFIC_VALIDATION", url: response.url, status_code: response.status)
+        elsif (400..599).cover? response.status
           resource_hash = { url: response.url, status_code: response.status }
           failed_resources << resource_hash
-          Bunyan.current_logger.error(context: "verifying_network_traffic", url: response.url, status_code: response.status)
+          Bunyan.current_logger.error(context: "Verification failed, response code in range 400..599", url: response.url, status_code: response.status)
         elsif ! ENV['ALLOW_ALL_NETWORK_HOSTS'] && response.url =~ Bunyan::DISALLOWED_NETWORK_TRAFFIC_REGEXP
           resource_hash = { url: response.url, status_code: response.status }
           failed_resources << resource_hash
-          Bunyan.current_logger.error(context: "verifying_network_traffic", url: response.url, status_code: response.status, disallowed_network: "true")
+          Bunyan.current_logger.error(context: "Verification failed, url is blocked by Bunyan::DISALLOWED_NETWORK_TRAFFIC_REGEXP", url: response.url, status_code: response.status, disallowed_network: "true")
         else
-          Bunyan.current_logger.debug(context: "verifying_network_traffic", url: response.url, status_code: response.status)
+          resource_hash = { url: response.url, status_code: response.status }
+          verification_passed_resources << resource_hash
+          Bunyan.current_logger.debug(context: "Verification passed", url: response.url, status_code: response.status)
         end
       end
     end


### PR DESCRIPTION
## Updates VerifyNetworkTraffic module

5127e24d536a0466634c93c87691a9222dd9e370

* Adds an array called 'EXCLUDE_URI_FROM_NETWORK_TRAFFIC_VALIDATION'
that can be used as a hook to exclude URIs in any spec
* Filters out non-URI resources because they don't have response codes
and their validation needs to be handled differently
* Skips verification of resources that have been included in
EXCLUDE_URI_FROM_NETWORK_TRAFFIC_VALIDATION
* Categorizes all network resources into 4 groups, for ease of
troubleshooting and logging
* Adds documentation about the 'verify_network_traffic' method

## Adding resource to be excluded for curate tests to pass

190ace602b86d989e9f2e3301d50848a669b392a

## Explicitly require Curate::Pages::HomePage

df3e6c91c256e8b11c6e68552a95220f26595150

For some reason, the curate_spec_helper won't require all files
in spec/curate/pages unless I first explicitly require
`spec/curate/pages/home_page.rb`

Without this change specs fail with an error:
``` console
uninitialized constant Curate::Pages::HomePage
```