### PR TITLE
Updating login specs after CAS upgrade

### DIFF
--- a/spec/curate/pages/login_page.rb
+++ b/spec/curate/pages/login_page.rb
@@ -4,8 +4,8 @@ require 'curate/curate_spec_helper'
 
 class LoginPage
   def checkLoginPage
-    page.has_content?("Login to Curate")
+    page.has_content?("Central Authentication Service")
     find('#password')
-    find('button[name="submit"]', :text => 'LOGIN')
+    find('#username')
   end
 end

--- a/spec/spec_support/cas_login.rb
+++ b/spec/spec_support/cas_login.rb
@@ -65,15 +65,7 @@ class LoginPage
     fill_in('username', with: userName)
     fill_in('password', with: passWord)
     find('.form-signin [name=submit]').trigger('click')
-    page.has_selector?("input[name=passcode]")
-    fill_in('passcode', with: passCode)
-    page.has_selector?('.form-signin [name=submit]')
-    # keeps clicking until the cas login page is gone (TEMP FIX)
-    loop do
-      find('.form-signin [name=submit]').trigger('click')
-      break if page.has_no_selector?('.form-signin [name=submit]')
-      # waits for it to leave the login page
-    end
+    page.has_no_selector?('.form-signin [name=submit]')
     current_logger.info(context: "Logging in user: #{userName}")
   end
 end


### PR DESCRIPTION
## Bypassing passcode input for login

5cf6a2bed94aa159dedb85d01eefff7c3880738f

After the CAS upgrade, the login page no longer asks for a passcode
for the testing IDs.
This is a temporary fix and will be reverted once the accounts have
been setup correctly again.

## Generalizing assertions of login page

a65f35d02a3dff8c21c8a7b95987489ec8959c37