### PR TITLE
Updates Rbsc specs for meltdown testing

### DIFF
--- a/spec/rbsc/functional/func_rbsc_spec.rb
+++ b/spec/rbsc/functional/func_rbsc_spec.rb
@@ -2,11 +2,12 @@
 require 'rbsc/rbsc_spec_helper'
 
 feature 'User Browsing', js: true do
-  scenario 'Load homepage' do
+  scenario 'Load homepage', :smoke_test do
     # Setting js_error false will suppress errors coming back from the site and let the tests finish
     page.driver.browser.js_errors = false
     visit '/'
-    puts current_url
+    expect(page).to have_content 'Rare Books & Special Collections'
+    expect(page).to have_content 'List of Finding Aids'
     within('#main-menu') do
       expect(page).to have_css 'li', count: 6
     end

--- a/spec/rbsc/rbsc_config.yml
+++ b/spec/rbsc/rbsc_config.yml
@@ -1,3 +1,4 @@
 local: jello
-pprd: https://ead-preview-pprd.library.nd.edu
+staging: https://ead-preview-staging.library.nd.edu
+prep: https://ead-preview-pprd.library.nd.edu
 prod: https://ead-preview-prod-vm.library.nd.edu


### PR DESCRIPTION
## Updating config

161b6d083b952f1ba20b4ba3468c53f7ace9eb19

* Making keys consistent with staging, prep, prod format, so its easier to run tests across the framework (let's say against all 'prep' envs)
* Adding 'staging' URL

## Updating RBSC functional spec

de885da0851371566e865d01d97c5b5db6574cb5

* Adds a 'smoke_test' tag for running specs during large changes
* Adds more assertions to validate homepage