### PR TITLE
Fixes condition when instance variable is nil

### DIFF
--- a/spec/spec_support/test_runtime.rb
+++ b/spec/spec_support/test_runtime.rb
@@ -204,7 +204,7 @@ module VerifyNetworkTraffic
           resource_hash = { url: response.url, status_code: response.status }
           non_uri_resources << resource_hash
           Bunyan.current_logger.debug(context: "Verification skipped, Resource isn't of type URI", url: response.url, status_code: response.status)
-        elsif @exclude_uri_from_network_traffic_validation.include? URI.parse(response.url).request_uri
+        elsif !@exclude_uri_from_network_traffic_validation.nil? && (@exclude_uri_from_network_traffic_validation.include? URI.parse(response.url).request_uri)
           resource_hash = { url: response.url, status_code: response.status }
           not_verified_resources << resource_hash
           Bunyan.current_logger.debug(context: "Verification skipped, resource exists in @exclude_uri_from_network_traffic_validation", url: response.url, status_code: response.status)


### PR DESCRIPTION
## Fixes condition when instance variable is nil

fc012ffdfd58a2d7bb3979d92e2c736fd545654e

Not all specs are using the hook for excluding URIs from network
validation. In that case the instance variable
'@exclude_uri_from_network_traffic_validation' does not get created and
is 'nil'. The 'verify_network_traffic' method then fails with error:
```error
"class": "NoMethodError",
"message": "undefined method `include?' for nil:NilClass"
```

This fix adds an additional condition to check if the class variable
is not nil.