### PR TITLE
Adds scenarios for testing solr instances

### DIFF
--- a/spec/solr/functional/func_solr_spec.rb
+++ b/spec/solr/functional/func_solr_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'solr/solr_spec_helper'
+# Using the SOLR Ping API to check status of SOLR
+# https://lucene.apache.org/solr/guide/6_6/ping.html#api-examples
+feature 'Ping SOLR status', js: true do
+  scenario 'For "curate" core', :smoke_test do
+    visit '/solr/curate/admin/ping?wt=ruby'
+    expect(eval(page.text).fetch('status')).to eq('OK')
+  end
+
+  scenario 'For "inquisition" core', :smoke_test do
+    visit '/solr/inquisition/admin/ping?wt=ruby'
+    expect(eval(page.text).fetch('status')).to eq('OK')
+  end
+
+  scenario 'For "medieval_micro" core', :smoke_test do
+    visit '/solr/medieval_micro/admin/ping?wt=ruby'
+    expect(eval(page.text).fetch('status')).to eq('OK')
+  end
+end

--- a/spec/solr/solr_config.yml
+++ b/spec/solr/solr_config.yml
@@ -1,0 +1,3 @@
+local: jello
+prep: secret_url
+prod: secret_url

--- a/spec/solr/solr_spec_helper.rb
+++ b/spec/solr/solr_spec_helper.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'spec_helper'


### PR DESCRIPTION
## Adds scenarios for testing solr instances

585e077800254aeb186cac4458e47c87c15b0e1c

* Reads SOLR URLs from corpFS for 'prep' and 'prod'
* Pings application specific cores for curate, inquisitions and
medieval_micro
* Verifies that the 'status' key in the response hash has value 'OK'

As per SOLR documentation, this test is sufficient to confirm that the
instances are working and responding:
https://lucene.apache.org/solr/guide/6_6/ping.html
"A status=OK indicates that the nodes are responding"