### PR TITLE
Spec for testing buzz for meltdown vulnerability

### DIFF
--- a/spec/buzz/buzz_config.yml
+++ b/spec/buzz/buzz_config.yml
@@ -1,0 +1,1 @@
+prod: https://buzz.library.nd.edu

--- a/spec/buzz/buzz_spec_helper.rb
+++ b/spec/buzz/buzz_spec_helper.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+Dir.glob(File.expand_path('../pages/**/*.rb', __FILE__)).each do |filename|
+  require filename
+end

--- a/spec/buzz/functional/func_buzz_spec.rb
+++ b/spec/buzz/functional/func_buzz_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'buzz/buzz_spec_helper'
+
+feature 'Verify a media file', js: true do
+  scenario 'Returns valid JSON', :smoke_test do
+    visit '/v1/media_files/31112b1e-6a1a-4307-8d00-d298a5c0a6ed'
+    response = Buzz::BuzzPlayer.new
+    expect(response).to be_valid_response
+  end
+end

--- a/spec/buzz/pages/buzz_player.rb
+++ b/spec/buzz/pages/buzz_player.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Buzz
+  class BuzzPlayer
+    include Capybara::DSL
+    include CapybaraErrorIntel::DSL
+
+    def valid_response?
+      @json_response = JSON.parse(page.text)
+      is_url_key_valid? &&
+        is_embed_url_key_valid? &&
+        is_content_url_key_valid?
+    end
+
+    # Checks if the 'url' field of JSON response is set correctly
+    def is_url_key_valid?
+      @json_response.fetch('url') == current_url
+    end
+
+    # embedUrl is the link used by other applications to stream media from buzz
+    # For example in this case, https://collections.library.nd.edu/7eff2d10c7/freshwriting-multimedia/items/10595b52e8
+    # This method ensures that the ID in current_url is set correctly in the value for 'embedUrl' key
+    def is_embed_url_key_valid?
+      embed_url_value = @json_response.fetch('embedUrl')
+      query_params = URLHandler.extract_query_parameters_from_url(embed_url_value)
+      current_url.include?(query_params.fetch('id'))
+    end
+
+    # values for contentURl key must be a valid wowza URL
+    def is_content_url_key_valid?
+      @json_response.fetch('contentUrl').all? { |each_url| !each_url.match('wowza.library.nd.edu').nil? }
+    end
+  end
+end

--- a/spec/spec_support/url_handler.rb
+++ b/spec/spec_support/url_handler.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module URLHandler
+  # Return the query parameters from given URL
+  # @param [String] url
+  # @return [Hash]
+  def self.extract_query_parameters_from_url(url)
+    Rack::Utils.parse_query(URI(url).query)
+  end
+end


### PR DESCRIPTION
## Creates a URLHandler module

671e34164a32b251781a273be16a8d51b329f7c3

This module will have helper methods to help with URL parsing needs
across the framework

## Adds specs for Buzz application

cc62e4a2f026d4a91e323dffd88b4036ccdfda01

* Verifies that buzz server returns a valid JSON
* The assertions make sure that the values of various keys in
the JSON response are set correctly.
* These assertions make sure that the consuming applications are
able to stream
* NOTE: This isn't an ideal way to ensure that the server works
as expected, but is a good start for smoke tests.