### PR TITLE
Tests for searching Primo

### DIFF
--- a/spec/primo/functional/func_primo_spec.rb
+++ b/spec/primo/functional/func_primo_spec.rb
@@ -22,4 +22,19 @@ feature 'User browsing', js: true do
     search_results_page = Primo::Pages::SearchResultsPage.new
     expect(search_results_page).to be_on_page
   end
+
+  scenario 'User searches NDCatalog' do
+    page.driver.browser.js_errors = false
+    visit '/'
+    home_page = Primo::Pages::HomePage.new
+    expect(home_page).to be_on_page
+    # This selects the NDcatalog tab
+    click_on('Search materials held by all Notre Dame campus libraries')
+    expect(home_page).to be_ndcatalog_tab_activated
+    search_term = 'Automated Testing'
+    fill_in('search_field', with: search_term)
+    find_button(id: 'goButton').trigger('click')
+    search_results_page = Primo::Pages::SearchResultsPage.new
+    expect(search_results_page).to be_on_page
+  end
 end

--- a/spec/primo/functional/func_primo_spec.rb
+++ b/spec/primo/functional/func_primo_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'primo/primo_spec_helper'
+
+feature 'User browsing', js: true do
+  scenario 'Load homepage', :smoke_test do
+    page.driver.browser.js_errors = false
+    visit '/'
+    home_page = Primo::Pages::HomePage.new
+    expect(home_page).to be_on_page
+  end
+end

--- a/spec/primo/functional/func_primo_spec.rb
+++ b/spec/primo/functional/func_primo_spec.rb
@@ -9,4 +9,17 @@ feature 'User browsing', js: true do
     home_page = Primo::Pages::HomePage.new
     expect(home_page).to be_on_page
   end
+
+  scenario 'User searches OneSearch' do
+    page.driver.browser.js_errors = false
+    visit '/'
+    home_page = Primo::Pages::HomePage.new
+    expect(home_page).to be_on_page
+    expect(home_page).to be_onesearch_tab_activated
+    search_term = 'Automated Testing'
+    fill_in('search_field', with: search_term)
+    find_button(id: 'goButton').trigger('click')
+    search_results_page = Primo::Pages::SearchResultsPage.new
+    expect(search_results_page).to be_on_page
+  end
 end

--- a/spec/primo/pages/home_page.rb
+++ b/spec/primo/pages/home_page.rb
@@ -26,6 +26,16 @@ module Primo
           find_button(id: 'goButton')
         end
       end
+
+      def onesearch_tab_activated?
+        # Check if the onesearch tab is selected
+       find('a.active.tab.onesearch.EXLSearchTabTitle.EXLSearchTabLABELOneSearch')
+      end
+
+      def ndcatalog_tab_activated?
+        # Check if the NDcatalog tab is selected
+        find('a.active.tab.ndcatalog.EXLSearchTabTitle.EXLSearchTabLABELND.Campus')
+      end
     end
   end
 end

--- a/spec/primo/pages/home_page.rb
+++ b/spec/primo/pages/home_page.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Primo
+  module Pages
+    class HomePage
+      include Capybara::DSL
+      include CapybaraErrorIntel::DSL
+      VerifyNetworkTraffic.exclude_uri_from_network_traffic_validation.push('/PDSMExlibris.css')
+      def on_page?
+        on_valid_url? &&
+          status_response_ok? &&
+          valid_page_content?
+      end
+
+      def on_valid_url?
+        current_url == File.join(Capybara.app_host, '/primo_library/libweb/action/search.do?vid=NDU')
+      end
+
+      def status_response_ok?
+        status_code.to_s.match(/^20[0,1,6]$/)
+      end
+
+      def valid_page_content?
+        within('#search_box') do
+          find_field(id: 'search_field')
+          find_button(id: 'goButton')
+        end
+      end
+    end
+  end
+end

--- a/spec/primo/pages/search_results_page.rb
+++ b/spec/primo/pages/search_results_page.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Primo
+  module Pages
+    class SearchResultsPage
+      include Capybara::DSL
+      include CapybaraErrorIntel::DSL
+      def on_page?
+        on_valid_url? &&
+          status_response_ok? &&
+          has_results?
+      end
+
+      def on_valid_url?
+        # NOTE: This check skips matching URI
+        !current_url.match(Capybara.app_host).nil?
+      end
+
+      def status_response_ok?
+        status_code.to_s.match(/^20[0,1,6]$/)
+      end
+
+      def has_results?
+        within('#resultsListNoId') do
+          !find('table#exlidResultsTable').find_all('tr').empty?
+        end
+      end
+    end
+  end
+end

--- a/spec/primo/pages/search_results_page.rb
+++ b/spec/primo/pages/search_results_page.rb
@@ -21,6 +21,7 @@ module Primo
       end
 
       def has_results?
+        page.has_content?('LIMIT RESULTS BY')
         within('#resultsListNoId') do
           !find('table#exlidResultsTable').find_all('tr').empty?
         end

--- a/spec/primo/primo_config.yml
+++ b/spec/primo/primo_config.yml
@@ -1,0 +1,2 @@
+prep: https://onesearchpprd.library.nd.edu
+prod: http://onesearch.library.nd.edu/

--- a/spec/primo/primo_spec_helper.rb
+++ b/spec/primo/primo_spec_helper.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+Dir.glob(File.expand_path('../pages/**/*.rb', __FILE__)).each do |filename|
+  require filename
+end


### PR DESCRIPTION
## Adds first scenario for testing primo

ce37c287ea24f2d3c149ff4ac755d42a08bff829

* Creates folder structure for spec/primo
* Adds first scenario
* Exclude static assets from network verification that are not
 loading in non-prod

## Adds methods to check if tabs are selected

75c2f7e7aaf46cdecd74a70778864e6bbad2b508

* These methods are serving as helper methods when switching between
onesearch and NDCatalog in the scenarios.

## Adds scenario for search with Onesearch

6adbdf50baf87a4a81073710639cd99f66ee2daa

* Loads homepage, checks if Onesearch tab is selected,
enters a search term, clicks search and verifies results page
* Results page verification only checks is the URL is on
Primo and does not verify the URI. I preferred this approach
because the URI has many parameters that keep changing over time
* Results page also verifies status code and if results table is not
empty

## Adds scenario for searching with NDCatalog

c8cf6cabc29fdbdbc789c5620b8d5eecb95271fe

This scenario is identical to the one searching with Onesearch
except that there is a step in between to click the NDcatolog tab

## Leveraging maleficent sleep injector

84771aaaeb838c66070a46dddffd8231c4ddf4c9