### PR TITLE
DLTP-1203: Featured Collections

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.1.2)
+    activesupport (5.1.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.5.1)
-      public_suffix (~> 2.0, >= 2.0.2)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     airborne (0.2.13)
       activesupport
       rack
@@ -36,14 +36,14 @@ GEM
     capistrano-bundler (1.2.0)
       capistrano (~> 3.1)
       sshkit (~> 1.2)
-    capybara (2.14.3)
+    capybara (2.17.0)
       addressable
-      mime-types (>= 1.16)
+      mini_mime (>= 0.1.3)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
-      xpath (~> 2.0)
-    capybara-maleficent (0.1.0)
+      xpath (>= 2.0, < 4.0)
+    capybara-maleficent (0.2.0)
       activesupport (>= 4.2.0)
       capybara (~> 2.13)
     capybara-screenshot (1.0.14)
@@ -104,7 +104,8 @@ GEM
     http_parser.rb (0.6.0)
     httpclient (2.8.3)
     hurley (0.2)
-    i18n (0.8.4)
+    i18n (0.9.3)
+      concurrent-ruby (~> 1.0)
     jmespath (1.3.1)
     json (1.8.6)
     json-schema (2.8.0)
@@ -118,16 +119,17 @@ GEM
       multi_json (~> 1.10)
     memoist (0.16.0)
     mime-types (2.99.3)
-    mini_portile2 (2.2.0)
-    minitest (5.10.2)
+    mini_mime (1.0.0)
+    mini_portile2 (2.3.0)
+    minitest (5.11.3)
     multi_json (1.12.1)
     multipart-post (2.0.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (4.1.0)
     netrc (0.11.0)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
     os (0.9.6)
     parallel (1.11.2)
     parser (2.4.0.0)
@@ -137,10 +139,10 @@ GEM
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
-    public_suffix (2.0.5)
+    public_suffix (3.0.1)
     rack (2.0.3)
-    rack-test (0.6.3)
-      rack (>= 1.0)
+    rack-test (0.8.2)
+      rack (>= 1.0, < 3)
     rainbow (2.2.2)
       rake
     rake (12.0.0)
@@ -194,7 +196,7 @@ GEM
       json-schema (~> 2.2)
       mime-types (~> 2.0)
     thread_safe (0.3.6)
-    tzinfo (1.2.3)
+    tzinfo (1.2.4)
       thread_safe (~> 0.1)
     uber (0.1.0)
     unf (0.1.4)
@@ -204,8 +206,8 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
-    xpath (2.1.0)
-      nokogiri (~> 1.3)
+    xpath (3.0.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
@@ -235,4 +237,4 @@ DEPENDENCIES
   swagger-parser
 
 BUNDLED WITH
-   1.15.1
+   1.16.0.pre.3

--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -505,28 +505,28 @@ feature 'Logged in user changing ORCID settings:', js: true do
 end
 
 feature 'Featured Collections:', js: true do
-  scenario 'Patents', :read_only, focus: true do
+  scenario 'Patents', :read_only do
     visit '/'
     click_on('Notre Dame Patents')
     catalog_page = Curate::Pages::CatalogPage.new(category: :patents)
     expect(catalog_page).to be_on_page
   end
 
-  scenario 'Press', :read_only, focus: true do
+  scenario 'Press', :read_only do
     visit '/'
     click_on('Notre Dame Press')
     catalog_page = Curate::Pages::CatalogPage.new(category: :press)
     expect(catalog_page).to be_on_page
   end
 
-  scenario 'Thesis & Dissertations', :read_only, focus: true do
+  scenario 'Thesis & Dissertations', :read_only do
     visit '/'
     click_on('Graduate School Thesis & Dissertations')
     catalog_page = Curate::Pages::CatalogPage.new(category: :thesis)
     expect(catalog_page).to be_on_page
   end
 
-  scenario 'Varieties of Democracy', :read_only, focus: true do
+  scenario 'Varieties of Democracy', :read_only do
     visit '/'
     click_on('Varieties of Democracy')
     catalog_page = Curate::Pages::CatalogPage.new(category: :varieties)

--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -40,14 +40,12 @@ feature 'User Browsing', js: true do
     expect(catalog_page).to be_on_base_url
   end
 
-  scenario 'Category search for Theses', :read_only do
+  scenario 'Category search for All Items', :read_only do
     visit '/'
-    title = 'Theses & Dissertations'
+    title = 'All Items'
     click_on(title)
-    category_page = Curate::Pages::CatalogPage.new(category: :thesis)
+    category_page = Curate::Pages::CatalogPage.new({})
     expect(category_page).to be_on_page
-    click_on('Clear all')
-    expect(category_page).to be_on_base_url
   end
 
   scenario 'Category search for Articles', :read_only do
@@ -62,7 +60,7 @@ feature 'User Browsing', js: true do
 
   scenario 'Category search for Datasets', :read_only do
     visit '/'
-    title = 'Datasets & Related Materials'
+    title = 'Datasets & Related Items'
     click_on(title)
     category_page = Curate::Pages::CatalogPage.new(category: :dataset)
     expect(category_page).to be_on_page
@@ -77,9 +75,9 @@ feature 'User Browsing', js: true do
     expect(contribute_page).to be_on_page
   end
 
-  scenario 'Materials by Department link', :read_only do
+  scenario 'Items by Department link', :read_only do
     visit '/'
-    click_on('Materials by Department')
+    click_on('Items by Department')
     dept_page = Curate::Pages::DepartmentsPage.new
     expect(dept_page).to be_on_page
     departmental_link = dept_page.select_random_departmental_link

--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -503,3 +503,33 @@ feature 'Logged in user changing ORCID settings:', js: true do
     expect(orcid_home_page).to be_on_page
   end
 end
+
+feature 'Featured Collections:', js: true do
+  scenario 'Patents', :read_only, focus: true do
+    visit '/'
+    click_on('Notre Dame Patents')
+    catalog_page = Curate::Pages::CatalogPage.new(category: :patents)
+    expect(catalog_page).to be_on_page
+  end
+
+  scenario 'Press', :read_only, focus: true do
+    visit '/'
+    click_on('Notre Dame Press')
+    catalog_page = Curate::Pages::CatalogPage.new(category: :press)
+    expect(catalog_page).to be_on_page
+  end
+
+  scenario 'Thesis & Dissertations', :read_only, focus: true do
+    visit '/'
+    click_on('Graduate School Thesis & Dissertations')
+    catalog_page = Curate::Pages::CatalogPage.new(category: :thesis)
+    expect(catalog_page).to be_on_page
+  end
+
+  scenario 'Varieties of Democracy', :read_only, focus: true do
+    visit '/'
+    click_on('Varieties of Democracy')
+    catalog_page = Curate::Pages::CatalogPage.new(category: :varieties)
+    expect(catalog_page).to be_on_page
+  end
+end

--- a/spec/curate/pages/catalog_page.rb
+++ b/spec/curate/pages/catalog_page.rb
@@ -11,25 +11,37 @@ module Curate
       attr_reader :search_term, :category, :departmental_link
 
       LOOKUP_CATEGORY_URL = {
-        thesis: "/catalog?f_inclusive%5Bhuman_readable_type_sim%5D%5B%5D=Doctoral+Dissertation&f_inclusive%5Bhuman_readable_type_sim%5D%5B%5D=Master%27s+Thesis",
+        thesis: "/catalog?f_inclusive[human_readable_type_sim][]=Doctoral+Dissertation&f_inclusive[human_readable_type_sim][]=Master's+Thesis",
         article: "/catalog?f%5Bhuman_readable_type_sim%5D%5B%5D=Article",
-        dataset: "/catalog?f%5Bhuman_readable_type_sim%5D%5B%5D=Dataset"
+        dataset: "/catalog?f%5Bhuman_readable_type_sim%5D%5B%5D=Dataset",
+        patents: "/catalog?f[library_collections_pathnames_hierarchy_with_titles_sim][]=Notre+Dame+Patents|und%3Azw12z32008t",
+        press: "/catalog?f[library_collections_pathnames_hierarchy_with_titles_sim][]=University+of+Notre+Dame+Press|und%3A1g05fb51m8t",
+        varieties: "/catalog?f[library_collections_pathnames_hierarchy_with_titles_sim][]=Varieties+of+Democracy|und%3A1z40ks6792x"
       }.freeze
       LOOKUP_CATEGORY_CAPTION = {
         thesis: "Theses & Dissertations",
         article: "Articles & Publications",
-        dataset: "Datasets & Related Items"
+        dataset: "Datasets & Related Materials",
+        patents: "Notre Dame Patents",
+        press: "Notre Dame Press",
+        varieties: "Varieties of Democracy"
       }.freeze
       LOOKUP_CATEGORY_VALUE = {
         thesis: "Doctoral Dissertation OR Master's Thesis",
         article: "Article",
-        dataset: "Dataset"
+        dataset: "Dataset",
+        patents: "Notre Dame Patents",
+        press: "Notre Dame Press",
+        varieties: "Varieties of Democracy"
       }.freeze
       LOOKUP_CATEGORY_FILTER = {
         thesis: "Type of Work:",
         article: "Type of Work:",
         dataset: "Type of Work:",
-        department: "Department or Unit:"
+        department: "Department or Unit:",
+        patents: "Collection:",
+        press: "Collection:",
+        varieties: "Collection:"
       }.freeze
 
       def initialize(search_term: nil, category: nil, departmental_link: nil)
@@ -70,13 +82,9 @@ module Curate
       end
 
       def valid_page_content?
-        within('.sidebar') do
-          return false unless has_content?('Filter by:')
-        end
+        return false unless page.find('.sidebar').has_content?('Filter by:')
         return true if category.nil?
-        within('h1') do
-          has_content?(category_caption)
-        end
+        page.find('h1').has_content?(category_caption)
       end
 
       def category_caption
@@ -92,17 +100,11 @@ module Curate
       end
 
       def valid_search_content?
-        within('.search-constraint-notice') do
-          return false unless has_content?('Search criteria:')
-        end
-        true
+        page.find('.search-constraint-notice').has_content?('Search criteria:')
       end
 
       def valid_filter_value?
-        within('.filter-value') do
-          return false unless has_content?(filter_value)
-        end
-        true
+        page.find('.filter-value').has_content?(filter_value)
       end
 
       def filter_value
@@ -113,10 +115,7 @@ module Curate
 
       def valid_filter_name?
         return true if category.nil?
-        within('.filter-name') do
-          return false unless has_content?(LOOKUP_CATEGORY_FILTER.fetch(category))
-        end
-        true
+        page.find('.filter-name').has_content?(LOOKUP_CATEGORY_FILTER.fetch(category))
       end
 
       def valid_content_count?

--- a/spec/curate/pages/catalog_page.rb
+++ b/spec/curate/pages/catalog_page.rb
@@ -18,7 +18,7 @@ module Curate
       LOOKUP_CATEGORY_CAPTION = {
         thesis: "Theses & Dissertations",
         article: "Articles & Publications",
-        dataset: "Datasets & Related Materials"
+        dataset: "Datasets & Related Items"
       }.freeze
       LOOKUP_CATEGORY_VALUE = {
         thesis: "Doctoral Dissertation OR Master's Thesis",

--- a/spec/curate/pages/catalog_page.rb
+++ b/spec/curate/pages/catalog_page.rb
@@ -82,9 +82,13 @@ module Curate
       end
 
       def valid_page_content?
-        return false unless page.find('.sidebar').has_content?('Filter by:')
+        within('.sidebar') do
+          return false unless has_content?('Filter by:')
+        end
         return true if category.nil?
-        page.find('h1').has_content?(category_caption)
+        within('h1') do
+          has_content?(category_caption)
+        end
       end
 
       def category_caption
@@ -100,11 +104,17 @@ module Curate
       end
 
       def valid_search_content?
-        page.find('.search-constraint-notice').has_content?('Search criteria:')
+        within('.search-constraint-notice') do
+          return false unless has_content?('Search criteria:')
+        end
+        true
       end
 
       def valid_filter_value?
-        page.find('.filter-value').has_content?(filter_value)
+        within('.filter-value') do |node|
+          return false unless has_content?(filter_value)
+        end
+        true
       end
 
       def filter_value
@@ -115,7 +125,10 @@ module Curate
 
       def valid_filter_name?
         return true if category.nil?
-        page.find('.filter-name').has_content?(LOOKUP_CATEGORY_FILTER.fetch(category))
+        within('.filter-name') do
+          return false unless has_content?(LOOKUP_CATEGORY_FILTER.fetch(category))
+        end
+        true
       end
 
       def valid_content_count?

--- a/spec/curate/pages/catalog_page.rb
+++ b/spec/curate/pages/catalog_page.rb
@@ -111,7 +111,7 @@ module Curate
       end
 
       def valid_filter_value?
-        within('.filter-value') do |node|
+        within('.filter-value') do
           return false unless has_content?(filter_value)
         end
         true

--- a/spec/curate/pages/departments_page.rb
+++ b/spec/curate/pages/departments_page.rb
@@ -24,7 +24,7 @@ module Curate
 
       def valid_page_content?
         within('.main-header') do
-          return false unless has_content?('Browse Materials by Department or Unit')
+          return false unless has_content?('Browse Items by Department or Unit')
         end
         within(".page-footer-wrapper") do
           return false unless has_link?('Help')


### PR DESCRIPTION
## Update tests to match featured collections changes (https://github.com/ndlib/curate_nd/pull/657)

bd7802b9f262541e24082c8892609ae09bf4dc12

- Theses search is now a search for all items, updated specs to check that the all items link goes to a basic search
- "Materials" has been changed to "Items" in most places, updated specs to match
- This does not yet add tests for the featured collection cards

3c323e7d28a9334ed405f621cd026cfedb1139ec

- Added new specs to test featured collection card links
- Found a problem with the way some of the specs were written. When performing a "has_content?" check within a "within" block, it would always return a Capybara::Session which is truthy, so was allowing all specs to pass these checks even when they shouldn't. Per the documentation, performing find chain is similar to the intended behavior, so changed several of the within checks to page.find.has_content? calls. Interesting enough, find_page_count method uses a within block and seemed to work fine. Not sure if this is because the 'find' works inside of the block and is scoped to the within or if it's just searching the entire page. Ie, perhaps the problem with performing scoped ops with a 'within' block is just limited to has_content? checks.

b0370047cb237fa0d8b6caaa368f031babbda9ec

- Found the problem with the has_content? checks was due to an interaction between the CapybaraErrorIntel gem and the Maleficent gem. This problem is fixed in Maleficent 0.2.0. Updated the lockfile and reverted the changes related to this bug back to their original form.