### PR TITLE
Updating specs per library website release r20180126

### DIFF
--- a/spec/usurper/pages/header_tab_all_checks.rb
+++ b/spec/usurper/pages/header_tab_all_checks.rb
@@ -16,14 +16,14 @@ module Usurper
           find_by_id('research').trigger('click')
         end
         within('.menu-drawer.visible') do
-          find('.more').trigger('click')
+          find('.viewAll.viewMore').trigger('click')
           current_url == File.join(Capybara.app_host, 'research')
         end
         within('.uNavigation') do
           find_by_id('services').trigger('click')
         end
         within('.menu-drawer.visible') do
-          find('.more').trigger('click')
+          find('.viewAll.viewMore').trigger('click')
           current_url == File.join(Capybara.app_host, 'services')
         end
       end

--- a/spec/usurper/pages/reseach_guides_page.rb
+++ b/spec/usurper/pages/reseach_guides_page.rb
@@ -4,7 +4,7 @@ module Usurper
     class ResearchGuidesPage < BasePage
       include Capybara::DSL
       include CapybaraErrorIntel::DSL
-
+      VerifyNetworkTraffic.exclude_uri_from_network_traffic_validation.push('/svn/loader/run_prettify.js', '/libapps/sites/3767/include/img/jesus.gif')
       def initialize
         last_opened_window = page.driver.browser.window_handles.last
         page.driver.browser.switch_to_window(last_opened_window)


### PR DESCRIPTION
## Skipping verification of 2 static assets

6f6998feb8a5b169b511c1805cad06b4430fdaf8

The 'research guides' page http://libguides.library.nd.edu/
is outside the realm of these specs. But there are certain
assets on this website that are not loading:
Status: 404 URL: https://google-code-prettify.googlecode.com/svn/loader/run_prettify.js
Status: 403 URL: http://s3.amazonaws.com/libapps/sites/3767/include/img/jesus.gif

Because of these resources the VerifyNetworkTraffic module reports
a 'ResourceError'.
This change adds these to URIs to be excluded from the network
verification

## Updates the search criteria for 'View more'

7ff68d6d011eed07a8d24b19234bbc3da0a4c8e9

Based on changes in Usurper (SPA) code
https://github.com/ndlib/usurper/pull/363