### PR TITLE
Adds a health check for bendo

### DIFF
--- a/spec/bendo/bendo_config.yml
+++ b/spec/bendo/bendo_config.yml
@@ -1,0 +1,2 @@
+prep: secret_url
+prod: secret_url

--- a/spec/bendo/bendo_spec_helper.rb
+++ b/spec/bendo/bendo_spec_helper.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+require 'spec_helper'
+Dir.glob(File.expand_path('../pages/**/*.rb', __FILE__)).each do |filename|
+  require filename
+end

--- a/spec/bendo/functional/func_bendo_spec.rb
+++ b/spec/bendo/functional/func_bendo_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+require 'bendo/bendo_spec_helper'
+
+feature 'Load health status page', js: true do
+  scenario 'Check version', :smoke_test do
+    visit '/'
+    health_status_page = Bendo::Pages::HealthStatusPage.new
+    expect(health_status_page).to be_on_page
+  end
+end

--- a/spec/bendo/pages/health_status_page.rb
+++ b/spec/bendo/pages/health_status_page.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+module Bendo
+  module Pages
+    class HealthStatusPage
+      include Capybara::DSL
+      include CapybaraErrorIntel::DSL
+
+      def on_page?
+        on_valid_url? &&
+          status_response_ok? &&
+          valid_page_content?
+      end
+
+      def on_valid_url?
+        current_url == Capybara.app_host || current_url == File.join(Capybara.app_host, '/')
+      end
+
+      def status_response_ok?
+        status_code == 200
+      end
+
+      def valid_page_content?
+        page.has_content?("Bendo")
+      end
+    end
+  end
+end


### PR DESCRIPTION
0d2fc8e32e592e6ac2dd1f396ab1e068bddc123e

* Endpoint URLs are stored in corpfs
* Checks if the page loads with a '200 OK' and looks for keyword
'Bendo' on the page.
* NOTE: I'm not verifying the version number of bendo in the assertion
This will be verified once I have a confirmation from devs about
their preferred method to store version number in the git repo