### PR TITLE
Updating config files and current_url tests on HomePage classes

### DIFF
--- a/spec/curate/curate_config.yml
+++ b/spec/curate/curate_config.yml
@@ -1,6 +1,6 @@
 local: jello
-staging6: https://libvirt6.library.nd.edu/
-staging8: https://libvirt8.library.nd.edu/
-staging9: https://libvirt9.library.nd.edu/
-pprd: https://curatepprd.library.nd.edu/
-prod: https://curate.nd.edu/
+staging6: https://libvirt6.library.nd.edu
+staging8: https://libvirt8.library.nd.edu
+staging9: https://libvirt9.library.nd.edu
+pprd: https://curatepprd.library.nd.edu
+prod: https://curate.nd.edu

--- a/spec/curate/pages/home_page.rb
+++ b/spec/curate/pages/home_page.rb
@@ -20,7 +20,7 @@ module Curate
       end
 
       def on_valid_url?
-        current_url == Capybara.app_host
+        current_url == Capybara.app_host || current_url == File.join(Capybara.app_host, '/')
       end
 
       def status_response_ok?

--- a/spec/curateBatchIngestor/pages/health_status_page.rb
+++ b/spec/curateBatchIngestor/pages/health_status_page.rb
@@ -12,7 +12,7 @@ module CurateBatchIngestor
       end
 
       def on_valid_url?
-        current_url == Capybara.app_host
+        current_url == Capybara.app_host || current_url == File.join(Capybara.app_host, '/')
       end
 
       def status_response_ok?

--- a/spec/dec/dec_config.yml
+++ b/spec/dec/dec_config.yml
@@ -1,3 +1,3 @@
 local: jello
-pprd: https://collections-pprd.library.nd.edu/
-prod: https://collections.library.nd.edu/
+pprd: https://collections-pprd.library.nd.edu
+prod: https://collections.library.nd.edu

--- a/spec/dec/pages/home_page.rb
+++ b/spec/dec/pages/home_page.rb
@@ -11,7 +11,7 @@ module Dec
       end
 
       def on_valid_url?
-        current_url == File.join(Capybara.app_host)
+        current_url == File.join(Capybara.app_host) || current_url == File.join(Capybara.app_host, '/')
       end
 
       def status_response_ok?
@@ -20,9 +20,9 @@ module Dec
 
       def valid_page_content?
         within('.collectionscover') do
-          has_css?('span', text: 'Digital Collections') 
+          has_css?('span', text: 'Digital Collections')
         end
-        within('.brand-bar') do 
+        within('.brand-bar') do
           find_link('University of Notre Dame', href: 'http://www.nd.edu') &&
           find_link('Hesburgh Libraries', href: 'http://library.nd.edu')
         end

--- a/spec/hesburghsite/hesburghsite_config.yml
+++ b/spec/hesburghsite/hesburghsite_config.yml
@@ -1,2 +1,2 @@
 local: jello
-pprd: https://hesarchivepprd-vm.library.nd.edu/
+pprd: https://hesarchivepprd-vm.library.nd.edu

--- a/spec/microfilms/microfilms_config.yml
+++ b/spec/microfilms/microfilms_config.yml
@@ -1,4 +1,4 @@
 local: jello
 staging: https://medievalstaging-vm.library.nd.edu
-prep: https://medievalpprd-vm.library.nd.edu/
+prep: https://medievalpprd-vm.library.nd.edu
 prod: https://medievalprod-vm.library.nd.edu

--- a/spec/primo/primo_config.yml
+++ b/spec/primo/primo_config.yml
@@ -1,2 +1,2 @@
 prep: https://onesearchpprd.library.nd.edu
-prod: http://onesearch.library.nd.edu/
+prod: http://onesearch.library.nd.edu

--- a/spec/seaside/pages/home_page.rb
+++ b/spec/seaside/pages/home_page.rb
@@ -14,7 +14,7 @@ module Seaside
       end
 
       def on_valid_url?
-        current_url == Capybara.app_host || File.join(Capybara.app_host, '#')
+        current_url == Capybara.app_host || File.join(Capybara.app_host, '/')
       end
 
       def valid_page_content?

--- a/spec/seaside/seaside_config.yml
+++ b/spec/seaside/seaside_config.yml
@@ -1,2 +1,2 @@
-prep: https://seasideprep.library.nd.edu/
-prod: https://seaside.library.nd.edu/
+prep: https://seasideprep.library.nd.edu
+prod: https://seaside.library.nd.edu

--- a/spec/sipity/pages/home_page.rb
+++ b/spec/sipity/pages/home_page.rb
@@ -12,7 +12,7 @@ module Sipity
       end
 
       def on_valid_url?
-        current_url == Capybara.app_host + 'areas/etd'
+        current_url == File.join(Capybara.app_host,'areas/etd')
       end
 
       def status_response_ok?

--- a/spec/sipity/sipity_config.yml
+++ b/spec/sipity/sipity_config.yml
@@ -1,3 +1,3 @@
 staging: https://sipity-staging.library.nd.edu
-prep: https://sipitypprd.library.nd.edu/
-prod: https://deposit.library.nd.edu/
+prep: https://sipitypprd.library.nd.edu
+prod: https://deposit.library.nd.edu

--- a/spec/spec_support/test_runtime.rb
+++ b/spec/spec_support/test_runtime.rb
@@ -98,8 +98,8 @@ module InitializeExample
   end
 
   def self.set_capybara_app_host(url)
-    Capybara.app_host = url
-    Bunyan.current_logger.debug(context: "Capybara.app_host set to #{url}")
+    Capybara.app_host = url.chomp("/")
+    Bunyan.current_logger.debug(context: "Capybara.app_host set to #{Capybara.app_host}")
   end
 
   def self.initialize_example_variables!

--- a/spec/usurper/usurper_config.yml
+++ b/spec/usurper/usurper_config.yml
@@ -1,3 +1,3 @@
-test: https://alpha.library.nd.edu/
-prep: https://beta.library.nd.edu/
-prod: https://library.nd.edu/
+test: https://alpha.library.nd.edu
+prep: https://beta.library.nd.edu
+prod: https://library.nd.edu

--- a/spec/vatican/pages/home_page.rb
+++ b/spec/vatican/pages/home_page.rb
@@ -12,7 +12,7 @@ module Vatican
       end
 
       def on_valid_url?
-        current_url == Capybara.app_host
+        current_url == Capybara.app_host || current_url = File.join(Capybara.app_host, '/')
       end
 
       def status_response_ok?

--- a/spec/vatican/vatican_config.yml
+++ b/spec/vatican/vatican_config.yml
@@ -1,2 +1,2 @@
-pprd: https://csthr-pprd.library.nd.edu/
-prod: https://csthr.library.nd.edu/
+pprd: https://csthr-pprd.library.nd.edu
+prod: https://csthr.library.nd.edu


### PR DESCRIPTION
With the new version of Capybara (2.17.0), the visit method adds a trailing slash to current_url.
This throws off the url tests in the HomePage classes.
To fix this, I have done the following to tests that were failing for the above reason:
* Make sure config files don't have trailing slashes
* always check for current_url with a '/'