### PR TITLE
Add coverage for bug DLTP-1229

### DIFF
--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -533,3 +533,11 @@ feature 'Featured Collections:', js: true do
     expect(catalog_page).to be_on_page
   end
 end
+
+feature 'Catalog Thumbnail Views:', js: true do
+  scenario 'Collections', :read_only do
+    visit '/catalog?f_inclusive[human_readable_type_sim][]=Collection&display=grid'
+    category_page = Curate::Pages::CatalogPage.new()
+    expect(category_page).to be_on_page
+  end
+end


### PR DESCRIPTION
Added a spec that tests the specific case of rendering collections in thumbnail view on the catalog page. This currently only covers the specific case uncovered by DLTP-1229. There is another ticket to expand this to other thumbnail views (DLTP-1269)