### PR TITLE
Creates 'List vs. Grid View of Types of Work' scenario and test_facets_list_vs_grid method

### DIFF
--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -542,7 +542,7 @@ feature 'Catalog Thumbnail Views:', js: true do
       find("a[data-target='#collapse_Type_of_Work']").click
     end
     within('#collapse_Type_of_Work.accordion-body.in.collapse') do
-      click_on('Show more')
+      find_link('Show more').trigger('click')
     end
     category_page = Curate::Pages::CatalogPage.new()
     category_page.test_facets_list_vs_grid

--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -535,9 +535,16 @@ feature 'Featured Collections:', js: true do
 end
 
 feature 'Catalog Thumbnail Views:', js: true do
-  scenario 'Collections', :read_only do
-    visit '/catalog?f_inclusive[human_readable_type_sim][]=Collection&display=grid'
+  scenario 'List vs. Grid View of Types of Work', :read_only do
+    visit '/'
+    click_on('All Items')
+    within('.facets') do
+      find("a[data-target='#collapse_Type_of_Work']").click
+    end
+    within('#collapse_Type_of_Work.accordion-body.in.collapse') do
+      click_on('Show more')
+    end
     category_page = Curate::Pages::CatalogPage.new()
-    expect(category_page).to be_on_page
+    category_page.test_facets_list_vs_grid
   end
 end

--- a/spec/curate/pages/catalog_page.rb
+++ b/spec/curate/pages/catalog_page.rb
@@ -143,6 +143,38 @@ module Curate
           return node_list[2].text
         end
       end
+
+      def test_facets_list_vs_grid
+        link_list = []
+        href_list = []
+        # Gets first list of Types of Work
+        link_list = all(:css, 'a.facet_select')
+        link_list.each do |link|
+          # Puts the hrefs of the links into a separate array because links become obsolete after page changes
+          href_list.append(link[:href])
+        end
+        unless find('.disabled.btn', text: 'Next »').visible?
+          within('.modal-footer') do
+            find_link('Next').trigger('click')
+          end
+          # Does this a second time because some facets are on the second page of ajax-modal
+          link_list = all(:css, 'a.facet_select')
+          link_list.each do |link|
+            href_list.append(link[:href])
+          end
+        end
+        # Actual testing starts here
+        href_list.each do |href|
+          visit href
+          on_page?
+          find('.display-type.listing.active')
+          find('.search-results-list')
+          # Switch to grid view
+          find('.display-type.grid').click
+          find('.display-type.grid.active')
+          find('.search-results-grid')
+        end
+      end
     end
   end
 end

--- a/spec/curate/pages/catalog_page.rb
+++ b/spec/curate/pages/catalog_page.rb
@@ -160,7 +160,7 @@ module Curate
           # Switch to grid view
           find('.display-type.grid').click
           find('.display-type.grid.active')
-          find('.search-results-grid')
+          ('.search-results-grid')
         end
       end
 
@@ -170,16 +170,22 @@ module Curate
         # Gets first list of Types of Work
         link_list = all(:css, 'a.facet_select')
         get_hrefs_from_links(link_list, href_list)
-        unless find('.disabled.btn', text: 'Next »').visible?
+        # Must sleep here in order for if statement to work 
+        sleep(1)
+        # This logic is because some of the environments(staging9) have only one page of links
+        if first('.disabled.btn', text: 'Next »')
+          # Testing for staging9 starts here
+          test_href_list(href_list)
+        else
           within('.modal-footer') do
             find_link('Next').trigger('click')
           end
           # Does this a second time because some facets are on the second page of ajax-modal
           link_list = all(:css, 'a.facet_select')
-          get_hrefs_froms_links(link_list, href_list)
+          get_hrefs_from_links(link_list, href_list)
+          # Testing for pprd and prod starts here
+          test_href_list(href_list)
         end
-        # Actual testing starts here
-        test_href_list(href_list)
       end
     end
   end

--- a/spec/curate/pages/catalog_page.rb
+++ b/spec/curate/pages/catalog_page.rb
@@ -144,26 +144,14 @@ module Curate
         end
       end
 
-      def test_facets_list_vs_grid
-        link_list = []
-        href_list = []
-        # Gets first list of Types of Work
-        link_list = all(:css, 'a.facet_select')
+      def get_hrefs_from_links(link_list, href_list)
         link_list.each do |link|
           # Puts the hrefs of the links into a separate array because links become obsolete after page changes
           href_list.append(link[:href])
         end
-        unless find('.disabled.btn', text: 'Next »').visible?
-          within('.modal-footer') do
-            find_link('Next').trigger('click')
-          end
-          # Does this a second time because some facets are on the second page of ajax-modal
-          link_list = all(:css, 'a.facet_select')
-          link_list.each do |link|
-            href_list.append(link[:href])
-          end
-        end
-        # Actual testing starts here
+      end
+
+      def test_href_list(href_list)
         href_list.each do |href|
           visit href
           on_page?
@@ -174,6 +162,24 @@ module Curate
           find('.display-type.grid.active')
           find('.search-results-grid')
         end
+      end
+
+      def test_facets_list_vs_grid
+        link_list = []
+        href_list = []
+        # Gets first list of Types of Work
+        link_list = all(:css, 'a.facet_select')
+        get_hrefs_from_links(link_list, href_list)
+        unless find('.disabled.btn', text: 'Next »').visible?
+          within('.modal-footer') do
+            find_link('Next').trigger('click')
+          end
+          # Does this a second time because some facets are on the second page of ajax-modal
+          link_list = all(:css, 'a.facet_select')
+          get_hrefs_froms_links(link_list, href_list)
+        end
+        # Actual testing starts here
+        test_href_list(href_list)
       end
     end
   end

--- a/spec/curate/pages/catalog_page.rb
+++ b/spec/curate/pages/catalog_page.rb
@@ -151,41 +151,54 @@ module Curate
         end
       end
 
+      def list_view_active?
+        find('.display-type.listing.active')
+        find('.search-results-list')
+      end
+
+      def grid_view_active?
+        find('.display-type.grid.active')
+        find('.search-results-grid')
+      end
+
       def test_href_list(href_list)
         href_list.each do |href|
           visit href
           on_page?
-          find('.display-type.listing.active')
-          find('.search-results-list')
+          list_view_active?
           # Switch to grid view
           find('.display-type.grid').click
-          find('.display-type.grid.active')
-          find('.search-results-grid')
+          grid_view_active?
         end
       end
 
       def test_facets_list_vs_grid
         link_list = []
         href_list = []
+        # Ensures that ajax_modal is on the page
+        has_css?('#ajax-modal')
         # Gets first list of Types of Work
-        link_list = all(:css, 'a.facet_select')
+        within('#ajax-modal') do
+          link_list = all(:css, 'a.facet_select')
+        end
         get_hrefs_from_links(link_list, href_list)
         # Must sleep here in order for if statement to work
         sleep(1)
         # This logic is because some of the environments(staging9) have only one page of links
-        if first('.disabled.btn', text: 'Next »')
-          # Testing for staging9 starts here
-          test_href_list(href_list)
-        else
+        unless first('.disabled.btn', text: 'Next »')
           within('.modal-footer') do
             find_link('Next').trigger('click')
+            # Ensures that ajax-modal is now on the second page
+            has_link?('Previous')
           end
           # Does this a second time because some facets are on the second page of ajax-modal
-          link_list = all(:css, 'a.facet_select')
+          within('#ajax-modal') do
+            link_list = all(:css, 'a.facet_select')
+          end
           get_hrefs_from_links(link_list, href_list)
-          # Testing for pprd and prod starts here
-          test_href_list(href_list)
         end
+        # Testing for grid and list view starts here
+        test_href_list(href_list)
       end
     end
   end

--- a/spec/curate/pages/catalog_page.rb
+++ b/spec/curate/pages/catalog_page.rb
@@ -160,7 +160,7 @@ module Curate
           # Switch to grid view
           find('.display-type.grid').click
           find('.display-type.grid.active')
-          ('.search-results-grid')
+          find('.search-results-grid')
         end
       end
 
@@ -170,7 +170,7 @@ module Curate
         # Gets first list of Types of Work
         link_list = all(:css, 'a.facet_select')
         get_hrefs_from_links(link_list, href_list)
-        # Must sleep here in order for if statement to work 
+        # Must sleep here in order for if statement to work
         sleep(1)
         # This logic is because some of the environments(staging9) have only one page of links
         if first('.disabled.btn', text: 'Next »')


### PR DESCRIPTION
Scenario:
* Tests the functionality of the list and grid views of the pages for each Type of Work

Method:
* Opens the ajax model for Types of Work to get the links for all Types of Work
* Puts the href of each link in a separate array to because links become obsolete
* Cycles through the page for each Type of Work and tests:
  * if CatalogPage class is on_page
  * if the list view is initially selected
  * if the resources are in list form with list view selected
  * if grid link becomes active when clicked
  * if the resources are in grid form when grid view is selected