### PR TITLE
Creates swagger_from_gateway method and creates toggle hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,11 @@ RELEASE_NUMBER: This toggle is only used for contentful_testing. When testing co
 ```console
 RELEASE_NUMBER=r20170922
 ```
+
+SWAGGER_LOCATION: Used to specify the swagger definition to use for integration tests, you must provide
+a value from either 'definitions' or 'gateway'.
+'definitions': Expects swagger definition in `definitions/swagger.yml` of the API's github repo
+'gateway': Expects swagger definition in `deploy/gateway.yml` of the APIS's github repo
 # Using Docker
 ## Pre-requisites:
 * Install Docker https://docs.docker.com/install/

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,6 +42,7 @@ RSpec.configure do |config|
   config.before(:suite) do |rspec_suite|
     @current_logger = Bunyan.start(example: rspec_suite, config: ENV, test_handler: self)
     Bunyan.current_logger = @current_logger
+    SwaggerHandler.require_swagger_location
     RunIdentifier.set
     CloudwatchEventHandler.set_aws_config
     new_save_path = ScreenshotsManager.get_screenshots_save_path

--- a/spec/spec_support/swagger_handler.rb
+++ b/spec/spec_support/swagger_handler.rb
@@ -93,11 +93,11 @@ class SwaggerHandler
     def self.require_swagger_location
       if SwaggerHandler.ensure_integration_test
         if ENV['SWAGGER_LOCATION'].nil?
-          Bunyan.current_logger.error(context: "SWAGGER LOCATION not found in ENV config")
-          Bunyan.current_logger.error(context: "Provide SWAGGER LOCATION of API being tested, ex: gateway")
+          Bunyan.current_logger.error(context: "SWAGGER_LOCATION not found in ENV config")
+          Bunyan.current_logger.error(context: "Provide SWAGGER_LOCATION of API being tested, ex: gateway")
           exit!
         elsif ENV['SWAGGER_LOCATION'] != "gateway" && ENV['SWAGGER_LOCATION'] != "definitions"
-          Bunyan.current_logger.error(context: "SWAGGER LOCATION is invalid.  Valid options are: definitions or gateway.")
+          Bunyan.current_logger.error(context: "SWAGGER_LOCATION is invalid.  Valid options are: definitions or gateway.")
           exit!
         end
       end


### PR DESCRIPTION
* Based on https://github.com/ndlib/QA_tests/issues/279
* The SwaggerHandler method, swagger, has been renamed swagger_from_definitions because definitions/swagger.yml is the location of that swagger file
  * Code has not been changed
* Creates the new method swagger_from_gateway which is similar to swagger_from definitions except it gets the swagger definition from deploy/gateway
  * Removed initial attempt to build swagger and rescue ArguementError because swagger definition is always nested in gateway files
* Adds require_swagger_location which forces tester to specify where the swagger should be loaded from in an ENV hook
  * ex: SWAGGER_LOCATION=gateway
  * SwaggerHandler.require_swagger_location is run in spec/spec_helper in the before(:suite) hook because SwaggerHandler is instantiated before examples
* Adds ensure_integration_test method to SwaggerHandler to ensure that SWAGGER_LOCATION is only required for integration tests