### PR TITLE
Add specs for file browsing/pagination

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -11,12 +11,13 @@ end
 #
 # *****************************************************************************
 
-CONFIG_KEYS = [:ENVIRONMENT, :LOG_LEVEL, :SKIP_CLOUDWATCH, :SKIP_VERIFY_NETWORK_TRAFFIC, :ALLOW_ALL_NETWORK_HOSTS, :USE_CONTENTFUL_SPACE, :VERSION_NUMBER, :RELEASE_NUMBER].freeze
+CONFIG_KEYS = [:ENVIRONMENT, :LOG_LEVEL, :SKIP_CLOUDWATCH, :SKIP_VERIFY_NETWORK_TRAFFIC, :SKIP_MALEFICENT, :ALLOW_ALL_NETWORK_HOSTS, :USE_CONTENTFUL_SPACE, :VERSION_NUMBER, :RELEASE_NUMBER].freeze
 
 ENVIRONMENT = ENV.fetch('ENVIRONMENT', Bunyan::DEFAULT_ENVIRONMENT)
 LOG_LEVEL = ENV.fetch('LOG_LEVEL', Bunyan::DEFAULT_LOG_LEVEL)
 SKIP_CLOUDWATCH = ENV.fetch('SKIP_CLOUDWATCH', nil)
 SKIP_VERIFY_NETWORK_TRAFFIC = ENV.fetch('SKIP_VERIFY_NETWORK_TRAFFIC', nil)
+SKIP_MALEFICENT = ENV.fetch('SKIP_MALEFICENT', nil)
 ALLOW_ALL_NETWORK_HOSTS = ENV.fetch('ALLOW_ALL_NETWORK_HOSTS', false)
 USE_CONTENTFUL_SPACE = ENV.fetch('USE_CONTENTFUL_SPACE', nil)
 VERSION_NUMBER = ENV.fetch('VERSION_NUMBER', nil)
@@ -46,6 +47,7 @@ if ARGV.grep(/-h/i).size == 1
   CONFIG_KEYS.each do |key|
     $stdout.puts "\t#{key}='#{Object.const_get(key)}'"
   end
+
   $stdout.puts ""
   $stdout.puts "Available LOG_LEVEL: #{Bunyan::AVAILABLE_LOG_LEVELS.join(', ')}"
   $stdout.puts "You can override the configuration option by adding the corresponding"
@@ -54,6 +56,7 @@ if ARGV.grep(/-h/i).size == 1
   $stdout.puts "Example:"
   $stdout.puts "$ ENVIRONMENT=local ./bin/#{File.basename(__FILE__)}"
   $stdout.puts ""
+
   $stdout.puts "SKIP_CLOUDWATCH: By default we notify CloudWatch of test events. In some cases,"
   $stdout.puts "this is not desired (e.g. local development). So you can set SKIP_CLOUDWATCH=true."
   $stdout.puts "ENV variable to not notify CloudWatch."
@@ -61,30 +64,41 @@ if ARGV.grep(/-h/i).size == 1
   $stdout.puts "Example:"
   $stdout.puts "$ SKIP_CLOUDWATCH=true ./bin/#{File.basename(__FILE__)}"
   $stdout.puts ""
+
   $stdout.puts "SKIP_VERIFY_NETWORK_TRAFFIC: By default we verify network traffic of all scenarios. In some cases,"
   $stdout.puts "this is not desired (e.g. testing beta sites). So you can set SKIP_VERIFY_NETWORK_TRAFFIC=true as part of the ENV."
   $stdout.puts ""
   $stdout.puts "Example:"
   $stdout.puts "$ SKIP_VERIFY_NETWORK_TRAFFIC=true ./bin/#{File.basename(__FILE__)}"
   $stdout.puts ""
+
+  $stdout.puts "SKIP_MALEFICENT: Do not use sleep injections for retrying tests that fail."
+  $stdout.puts ""
+  $stdout.puts "Example:"
+  $stdout.puts "$ SKIP_MALEFICENT=true ./bin/#{File.basename(__FILE__)}"
+  $stdout.puts ""
+
   $stdout.puts "ALLOW_ALL_NETWORK_HOSTS: By default we will skip network traffic from #{Bunyan::DISALLOWED_NETWORK_TRAFFIC_REGEXP.inspect}. If"
   $stdout.puts "this is not desired, ALLOW_ALL_NETWORK_HOSTS=true as part of the ENV."
   $stdout.puts ""
   $stdout.puts "Example:"
   $stdout.puts "$ ALLOW_ALL_NETWORK_HOSTS=true ./bin/#{File.basename(__FILE__)}"
   $stdout.puts ""
+
   $stdout.puts "USE_CONTENTFUL_SPACE: This toggle is only used for and required for contentful testing. When testing contentful, there are two options for contentful space: prod and prep."
   $stdout.puts "In order to use these spaces, the user needs a token from the shared drive which differs for each space. So, you must define which space you want for your test in the command line."
   $stdout.puts ""
   $stdout.puts "Example:"
   $stdout.puts "$ USE_CONTENTFUL_SPACE=prod ./bin/#{File.basename(__FILE__)}"
   $stdout.puts ""
+
   $stdout.puts "VERSION_NUMBER: When testing usurper, you must input the version number for the version of the site you want to test so that the tests run accurately and small design changes"
   $stdout.puts "from version to version do not cause failures."
   $stdout.puts ""
   $stdout.puts "Example:"
   $stdout.puts "$ VERSION_NUMBER=v2017.2 ./bin/#{File.basename(__FILE__)}"
   $stdout.puts ""
+
   $stdout.puts "RELEASE_NUMBER: This toggle is only used for contentful_testing. When testing contentful, you must provide a release number to define the stack of deployed VERSION_NUMBER(s)"
   $stdout.puts ""
   $stdout.puts "Example:"

--- a/spec/curate/pages/catalog_page.rb
+++ b/spec/curate/pages/catalog_page.rb
@@ -65,7 +65,7 @@ module Curate
           current_url.start_with?(File.join(Capybara.app_host, 'catalog'))
         elsif category.nil?
           current_url.start_with?(File.join(Capybara.app_host, 'catalog')) &&
-            current_url.include?(search_term)
+            current_url.include?(encoded_search_term)
         elsif caption.nil?
           current_url == File.join(Capybara.app_host, LOOKUP_CATEGORY_URL.fetch(category))
         else # use caption link
@@ -199,6 +199,15 @@ module Curate
         end
         # Testing for grid and list view starts here
         test_href_list(href_list)
+      end
+
+      def encoded_search_term
+        # If a search term has spaces, curate will convert them to +. If it has +, it will encode them. Ex:
+        #   "Article with many files" => "Article+with+many+files"
+        #   "Article+with+many+files" => "Article%2Bwith%2Bmany%2Bfiles"
+        result = URI.encode(search_term, /\+/)
+        result = result.gsub(/\s/, "+")
+        result
       end
     end
   end

--- a/spec/curate/pages/show_article.rb
+++ b/spec/curate/pages/show_article.rb
@@ -55,7 +55,7 @@ module Curate
         within("article.abstract.descriptive-text") do
           page.has_selector?("p", minimum: 1)
         end
-        within("table.table.table-striped") do
+        within("table.table.table-striped.document.attributes") do
           first('p')
         end
       end

--- a/spec/curate/pages/show_article.rb
+++ b/spec/curate/pages/show_article.rb
@@ -28,7 +28,21 @@ module Curate
       # Not all articles have downloads. Don't fail in a bad way if that is the case
       def has_files?
         begin
-          find("div.actions a.action.btn", text: "Download")
+          find("div.actions a.action.btn", text: "Download", match: :first)
+          return true
+        rescue Capybara::ElementNotFound
+          false
+        end
+      end
+
+      def has_pagination?(page_var = "page")
+        begin
+          within("div.pager div.page_links") do
+            find("li.prev-page")
+            next_page = find("li.next-page a")
+            # Also make sure it links with the correct page parameter
+            return next_page['href'] =~ (/.*[?&]#{page_var}=.*/)
+          end
           return true
         rescue Capybara::ElementNotFound
           false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ require 'capybara/poltergeist'
 require 'yaml'
 require 'capybara_error_intel/dsl'
 require 'capybara-screenshot/rspec'
-require 'capybara/maleficent/spindle' # Auto-inject sleep intervals into DOM interactions
+require 'capybara/maleficent/spindle' unless ENV['SKIP_MALEFICENT'] # Auto-inject sleep intervals into DOM interactions
 require 'logging'
 require 'rspec/logging_helper'
 require 'swagger'


### PR DESCRIPTION
## DLTP-1261: Add specs for file browsing/pagination

01ea4980fd08eb60675e7498901b7b837384eac5

- Added a way to disable maleficent. This is useful when iterating on a test that you know is failing
- Added a method to allow searching for a term with spaces. When this happens, the url of the page uses an encoded version of the search term. Changed on_valid_url? to check for encoded search term in the url
- Added a helper method within Article to test if pagination was rendered for the article and with the correct params
- The existing show article spec was not testing file downloads. This has been silently failing for a few reasons. First, the first article that it selects in the search may or may not have files (currently does not for pprd, for example). Second, the has_files? check was silently failing due to ambiguity if the article had multiple files. Fixed the ambiguity, moved this into a feature spec for testing file browsing and added specs for testing that pagination is rendered for an article with many files. Also fixed a problem with how it tests that the file was downloaded. Testing page url is not valid, have to check the response headers.