### PR TITLE
Hp tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,10 +173,11 @@ $ ./bin/run_tests spec/curate/functional/func_curate_spec.rb
 
 #### Testing on your local machine
 
+To see all available input variables and examples:
 ```console
 $ cd /path/to/QA_tests
-$ ./bin/run_tests spec/curate/functional/func_curate_spec.rb
-```
+$ ./bin/run_tests -h
+````
 
 #### Triggering from Jenkins CI
 

--- a/bin/run_tests
+++ b/bin/run_tests
@@ -11,9 +11,10 @@ end
 #
 # *****************************************************************************
 
-CONFIG_KEYS = [:ENVIRONMENT, :LOG_LEVEL, :SKIP_CLOUDWATCH, :SKIP_VERIFY_NETWORK_TRAFFIC, :SKIP_MALEFICENT, :ALLOW_ALL_NETWORK_HOSTS, :USE_CONTENTFUL_SPACE, :VERSION_NUMBER, :RELEASE_NUMBER].freeze
+CONFIG_KEYS = [:ENVIRONMENT, :ENVIRONMENT_CATEGORY, :LOG_LEVEL, :SKIP_CLOUDWATCH, :SKIP_VERIFY_NETWORK_TRAFFIC, :SKIP_MALEFICENT, :ALLOW_ALL_NETWORK_HOSTS, :USE_CONTENTFUL_SPACE, :VERSION_NUMBER, :RELEASE_NUMBER].freeze
 
 ENVIRONMENT = ENV.fetch('ENVIRONMENT', Bunyan::DEFAULT_ENVIRONMENT)
+ENVIRONMENT_CATEGORY = ENV.fetch('ENVIRONMENT_CATEGORY', nil)
 LOG_LEVEL = ENV.fetch('LOG_LEVEL', Bunyan::DEFAULT_LOG_LEVEL)
 SKIP_CLOUDWATCH = ENV.fetch('SKIP_CLOUDWATCH', nil)
 SKIP_VERIFY_NETWORK_TRAFFIC = ENV.fetch('SKIP_VERIFY_NETWORK_TRAFFIC', nil)
@@ -51,10 +52,20 @@ if ARGV.grep(/-h/i).size == 1
   $stdout.puts ""
   $stdout.puts "Available LOG_LEVEL: #{Bunyan::AVAILABLE_LOG_LEVELS.join(', ')}"
   $stdout.puts "You can override the configuration option by adding the corresponding"
-  $stdout.puts "ENV variable."
+  $stdout.puts "ENV variable key from spec/<app_you_are_testing>/<app_you_are_testing>_config.yml"
   $stdout.puts ""
   $stdout.puts "Example:"
   $stdout.puts "$ ENVIRONMENT=local ./bin/#{File.basename(__FILE__)}"
+  $stdout.puts ""
+  $stdout.puts "'ENVIRONMENT' can also be an endpoint URL"
+  $stdout.puts "Example:"
+  $stdout.puts "$ ENVIRONMENT=https://library.nd.edu ./bin/#{File.basename(__FILE__)}"
+  $stdout.puts ""
+  $stdout.puts "In that case, please specify whether endpoint is production or non_production using 'ENVIRONMENT_CATEGORY'"
+  $stdout.puts "ENVIRONMENT_CATEGORY can be one of: ['local', 'dev', 'test', 'prep', 'pprd', 'staging', 'staging6', 'staging8','staging9', 'prod']"
+  $stdout.puts "NOTE that some scenarios will be filtered out if you're running against production"
+  $stdout.puts "Example:"
+  $stdout.puts "$ ENVIRONMENT_CATEGORY=prod ENVIRONMENT=https://library.nd.edu ./bin/#{File.basename(__FILE__)}"
   $stdout.puts ""
 
   $stdout.puts "SKIP_CLOUDWATCH: By default we notify CloudWatch of test events. In some cases,"

--- a/spec/bendo/functional/func_bendo_spec.rb
+++ b/spec/bendo/functional/func_bendo_spec.rb
@@ -2,7 +2,7 @@
 require 'bendo/bendo_spec_helper'
 
 feature 'Load health status page', js: true do
-  scenario 'Check version', :smoke_test do
+  scenario 'Check version', :smoke_test, :read_only do
     visit '/'
     health_status_page = Bendo::Pages::HealthStatusPage.new
     expect(health_status_page).to be_on_page

--- a/spec/buzz/functional/func_buzz_spec.rb
+++ b/spec/buzz/functional/func_buzz_spec.rb
@@ -3,7 +3,7 @@
 require 'buzz/buzz_spec_helper'
 
 feature 'Verify a media file', js: true do
-  scenario 'Returns valid JSON', :smoke_test do
+  scenario 'Returns valid JSON', :smoke_test, :read_only do
     visit '/v1/media_files/31112b1e-6a1a-4307-8d00-d298a5c0a6ed'
     response = Buzz::BuzzPlayer.new
     expect(response).to be_valid_response

--- a/spec/classes/integration/int_classes_spec.rb
+++ b/spec/classes/integration/int_classes_spec.rb
@@ -3,7 +3,7 @@ require 'classes/classes_spec_helper'
 
 feature 'Classes API test' do
   SwaggerHandler.operations(for_file_path: __FILE__).each do |operation|
-    scenario "calls #{operation.verb} #{operation.path}" do
+    scenario "calls #{operation.verb} #{operation.path}", :read_only do
       schema = RequestBuilder.new(current_logger, operation)
       result = schema.send_via_operation_verb
       current_response = ResponseValidator.new(operation, result)

--- a/spec/contentful/integration/int_contentful_spec.rb
+++ b/spec/contentful/integration/int_contentful_spec.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 require 'contentful/contentful_spec_helper'
 
+# Both these scenarios are adding content in production but I'm still tagging
+# them as ':read_only' because they have a built in mechanism to cleanup
+# test data before finishing  the scenarios
 feature 'Tests for Contentful entries and webhook integrations' do
-  scenario "Create and preview an entry of type 'Page'" do
+  scenario "Create and preview an entry of type 'Page'", :read_only do
     ContentfulHandler.create(current_logger: current_logger) do |entry|
       entry.verify_webhooks
       expect(entry).not_to be_published
@@ -25,7 +28,7 @@ feature 'Tests for Contentful entries and webhook integrations' do
   # 'lib_cal_id' is a unique ID that is used to pull data from the libcal system
   # libcal ID is parameterized by leveraging the PathParameterizer::ParameterFinder
   # class along with the associated find method of ParameterFinder
-  scenario "Create and preview an entry of type 'Events'" do
+  scenario "Create and preview an entry of type 'Events'", :read_only do
     contentful_params = PathParameterizer::ParameterFinder.new(application_name_under_test: 'contentful')
     lib_cal_id = contentful_params.find(key: 'libCalId').to_s
     ContentfulHandler.create(current_logger: current_logger, content_type: 'event', lib_cal_id: lib_cal_id ) do |entry|

--- a/spec/crawler/crawl/web_crawler_spec.rb
+++ b/spec/crawler/crawl/web_crawler_spec.rb
@@ -5,7 +5,7 @@ require "net/http"
 require "uri"
 require "set"
 feature 'Link Checker' do
-  scenario 'Check Links' do
+  scenario 'Check Links', :read_only do
     begin
       File.foreach(ENV["HOME"] + "/crawl_sites.txt") do |root_url|
         root_url.strip!

--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -86,7 +86,7 @@ feature 'User Browsing', js: true do
     expect(dept_search_page).to be_on_page
   end
 
-  scenario "Show an Article" do
+  scenario "Show an Article", :read_only do
     visit '/'
     home_page = Curate::Pages::HomePage.new
     expect(home_page).to be_on_page
@@ -147,7 +147,7 @@ end
 
 feature 'Logged In User (Account details NOT updated) Browsing', js: true do
   let(:login_page) { LoginPage.new(current_logger, account_details_updated: false) }
-  scenario "Log in", :validates_login do
+  scenario "Log in", :validates_login, :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -155,7 +155,7 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     expect(logged_in_home_page).to be_on_page
   end
 
-  scenario "Manage My Works" do
+  scenario "Manage My Works", :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -167,7 +167,7 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     expect(works_page).to be_on_page
   end
 
-  scenario "Visit Manage My Groups page" do
+  scenario "Visit Manage My Groups page", :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -179,7 +179,7 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     expect(account_details_page).to be_on_page
   end
 
-  scenario "Visit Manage My Collections page" do
+  scenario "Visit Manage My Collections page", :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -191,7 +191,7 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     expect(account_details_page).to be_on_page
   end
 
-  scenario "Visit Manage My Profile page" do
+  scenario "Visit Manage My Profile page", :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -203,7 +203,7 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     expect(account_details_page).to be_on_page
   end
 
-  scenario "Visit Deposit New Article page" do
+  scenario "Visit Deposit New Article page", :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -215,7 +215,7 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     expect(account_details_page).to be_on_page
   end
 
-  scenario "Visit Deposit New Dataset page" do
+  scenario "Visit Deposit New Dataset page", :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -227,7 +227,7 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     expect(account_details_page).to be_on_page
   end
 
-  scenario "Visit Deposit New Document page" do
+  scenario "Visit Deposit New Document page", :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -239,7 +239,7 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     expect(account_details_page).to be_on_page
   end
 
-  scenario "Visit Deposit New Image page" do
+  scenario "Visit Deposit New Image page", :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -251,7 +251,7 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     expect(account_details_page).to be_on_page
   end
 
-  scenario "Visit More Options page" do
+  scenario "Visit More Options page", :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -263,7 +263,7 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     expect(account_details_page).to be_on_page
   end
 
-  scenario "Visit Deposit New Audio page" do
+  scenario "Visit Deposit New Audio page", :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -275,7 +275,7 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     expect(account_details_page).to be_on_page
   end
 
-  scenario "Visit Deposit New Senior Thesis page" do
+  scenario "Visit Deposit New Senior Thesis page", :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -287,7 +287,7 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     expect(account_details_page).to be_on_page
   end
 
-  scenario "Log out" do
+  scenario "Log out", :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -302,7 +302,7 @@ end
 
 feature 'Logged In User (Account details updated) Browsing', js: true do
   let(:login_page) { LoginPage.new(current_logger, account_details_updated: true) }
-  scenario "Log in", :validates_login do
+  scenario "Log in", :validates_login, :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -310,7 +310,7 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     expect(logged_in_home_page).to be_on_page
   end
 
-  scenario "Manage My Works", js: true do
+  scenario "Manage My Works", js: true, :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -322,7 +322,7 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     expect(works_page).to be_on_page
   end
 
-  scenario "Visit Manage My Groups page" do
+  scenario "Visit Manage My Groups page", :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -334,7 +334,7 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     expect(groups_page).to be_on_page
   end
 
-  scenario "Visit Manage My Collections page" do
+  scenario "Visit Manage My Collections page", :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -346,7 +346,7 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     expect(collections_page).to be_on_page
   end
 
-  scenario "Visit Manage My Profile page" do
+  scenario "Visit Manage My Profile page", :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -358,7 +358,7 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     expect(profile_page).to be_on_page
   end
 
-  scenario "Visit Manage My Delegates page" do
+  scenario "Visit Manage My Delegates page", :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -370,7 +370,7 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     expect(delegates_page).to be_on_page
   end
 
-  scenario "Visit Deposit New Article page" do
+  scenario "Visit Deposit New Article page", :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -382,7 +382,7 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     expect(article_page).to be_on_page
   end
 
-  scenario "Visit Deposit New Dataset page" do
+  scenario "Visit Deposit New Dataset page", :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -394,7 +394,7 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     expect(dataset_page).to be_on_page
   end
 
-  scenario "Visit Deposit New Document page" do
+  scenario "Visit Deposit New Document page", :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -406,7 +406,7 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     expect(document_page).to be_on_page
   end
 
-  scenario "Visit Deposit New Image page" do
+  scenario "Visit Deposit New Image page", :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -418,7 +418,7 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     expect(image_page).to be_on_page
   end
 
-  scenario "Visit More Options page" do
+  scenario "Visit More Options page", :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -430,7 +430,7 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     expect(options_page).to be_on_page
   end
 
-  scenario "Visit Deposit New Audio page" do
+  scenario "Visit Deposit New Audio page", :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -445,7 +445,7 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     expect(audio_page).to be_on_page
   end
 
-  scenario "Visit Deposit New Senior Thesis page" do
+  scenario "Visit Deposit New Senior Thesis page", :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -460,7 +460,7 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     expect(thesis_page).to be_on_page
   end
 
-  scenario "Log out" do
+  scenario "Log out", :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -474,7 +474,7 @@ end
 
 feature 'Logged in user changing ORCID settings:', js: true do
   let(:login_page) { LoginPage.new(current_logger, account_details_updated: false) }
-  scenario "Go to ORCID.org home page", :validates_login do
+  scenario "Go to ORCID.org home page", :validates_login, :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -541,7 +541,7 @@ feature 'Catalog Thumbnail Views:', js: true do
 end
 
 feature 'Browsing attached files' do
-  scenario "Show an Article with many files" do
+  scenario "Show an Article with many files", :read_only do
     visit '/'
     home_page = Curate::Pages::HomePage.new
     expect(home_page).to be_on_page

--- a/spec/curateBatchIngestor/functional/func_curateBatchIngestor_spec.rb
+++ b/spec/curateBatchIngestor/functional/func_curateBatchIngestor_spec.rb
@@ -2,13 +2,13 @@
 require 'curateBatchIngestor/curateBatchIngestor_spec_helper'
 
 feature 'Load health status page', js: true do
-  scenario 'Check version', :smoke_test do
+  scenario 'Check version', :smoke_test, :read_only do
     visit '/'
     health_status_page = CurateBatchIngestor::Pages::HealthStatusPage.new
     expect(health_status_page).to be_on_page
   end
 
-  scenario 'Check filesystems work', :smoke_test do
+  scenario 'Check filesystems work', :smoke_test, :read_only do
     visit '/jobs'
     jobs_status_page = CurateBatchIngestor::Pages::JobsStatusPage.new
     expect(jobs_status_page).to be_on_page

--- a/spec/dave/functional/func_dave_spec.rb
+++ b/spec/dave/functional/func_dave_spec.rb
@@ -54,17 +54,17 @@ end
 
 feature 'View DAVE Artifact', js: true do
   let(:site) { DaveSite.new }
-  scenario 'Load First Document' do
+  scenario 'Load First Document', :read_only do
     visitHome()
   end
 
-  scenario 'Select Next Image' do
+  scenario 'Select Next Image', :read_only do
     visitHome()
     visitNewPage(page: 1)
     expect(page.current_url).to eq(site.current_url_for_view_type(view_type: :one_page, page: 1))
   end
 
-  scenario 'Select Previous Image' do
+  scenario 'Select Previous Image', :read_only do
     visitHome()
     visitNewPage(page: 1)
     expect(page.current_url).to eq(site.current_url_for_view_type(view_type: :one_page, page: 1))
@@ -73,14 +73,14 @@ feature 'View DAVE Artifact', js: true do
     visitNewPage(page: 1)
     expect(page.current_url).to eq(site.current_url_for_view_type(view_type: :one_page, page: 1))
   end
-  scenario 'Select Last Image' do
+  scenario 'Select Last Image', :read_only do
     visitHome()
     last_page = getLastPage()
     visitNewPage(page: last_page)
     checkImageSelection(imageNumber: last_page)
   end
 
-  scenario 'Select First Image' do
+  scenario 'Select First Image', :read_only do
     visitHome()
     last_page = getLastPage()
     visitNewPage(page: last_page)
@@ -88,7 +88,7 @@ feature 'View DAVE Artifact', js: true do
     visitNewPage()
     checkImageSelection(imageNumber: 0)
   end
-  scenario 'Select Specific Page' do
+  scenario 'Select Specific Page', :read_only do
     visitHome()
     last_page = getLastPage()
     pageNumber = Random.rand(1..last_page)
@@ -99,7 +99,7 @@ feature 'View DAVE Artifact', js: true do
     checkImageSelection(imageNumber: pageNumber)
   end
 
-  scenario 'Make a Dropdown Selection' do
+  scenario 'Make a Dropdown Selection', :read_only do
     visitHome()
     last_page = getLastPage()
     pageNumber = Random.rand(1..last_page)
@@ -108,7 +108,7 @@ feature 'View DAVE Artifact', js: true do
     end
     checkImageSelection(imageNumber: pageNumber)
   end
-  scenario 'Go to Two Image View' do
+  scenario 'Go to Two Image View', :read_only do
     visitHome()
     twoPageViewURL = site.button_link_url(view_type: :two_page)
     within(bottom_Document_NavBar) do
@@ -126,7 +126,7 @@ feature 'View DAVE Artifact', js: true do
     first_doc = Dave::Pages::FirstDocument.new
     expect(first_doc).to be_two_page
   end
-  scenario 'Go to Grid Image View' do
+  scenario 'Go to Grid Image View', :read_only do
     visitHome()
     gridURL = site.button_link_url(view_type: :grid)
     within(bottom_Document_NavBar) do
@@ -135,7 +135,7 @@ feature 'View DAVE Artifact', js: true do
     expect(page.current_url).to eq(site.current_url_for_view_type(view_type: :grid))
   end
 
-  scenario 'Go to Detail View' do
+  scenario 'Go to Detail View', :read_only do
     visitHome()
     last_page = getLastPage()
     pageNumber = Random.rand(1..last_page)
@@ -158,7 +158,7 @@ feature 'View DAVE Artifact', js: true do
       expect(first_doc).to be_detail_view
     end
   end
-  scenario 'Visit Page from Current Document' do
+  scenario 'Visit Page from Current Document', :read_only do
     site.visit_from_current_document(page: 1)
     expect(page.current_url).to eq(site.current_url_for_view_type(view_type: :one_page, page: 1))
   end

--- a/spec/gatekeeper/integration/int_gatekeeper_spec.rb
+++ b/spec/gatekeeper/integration/int_gatekeeper_spec.rb
@@ -3,7 +3,7 @@ require 'gatekeeper/gatekeeper_spec_helper'
 
 feature 'Gatekeeper API test' do
   SwaggerHandler.operations(for_file_path: __FILE__).each do |operation|
-    scenario "calls #{operation.verb} #{operation.path}" do
+    scenario "calls #{operation.verb} #{operation.path}", :read_only do
       schema = RequestBuilder.new(current_logger, operation)
       result = schema.send_via_operation_verb
       current_response = ResponseValidator.new(operation, result)

--- a/spec/hathitrust/functional/func_hathitrust_spec.rb
+++ b/spec/hathitrust/functional/func_hathitrust_spec.rb
@@ -3,7 +3,7 @@ require 'hathitrust/hathitrust_spec_helper'
 
 feature 'Institutional Login', js: true do
   let(:login_page) { LoginPage.new(current_logger, account_details_updated: false) }
-  scenario 'Sign in by institution (Notre Dame)', :validates_login  do
+  scenario 'Sign in by institution (Notre Dame)', :validates_login, :read_only  do
     visit '/'
     find('#login-button').trigger('click')
     find('.button.continue').click

--- a/spec/hesburghsite/functional/func_hesburghsite_spec.rb
+++ b/spec/hesburghsite/functional/func_hesburghsite_spec.rb
@@ -2,7 +2,7 @@
 require 'hesburghsite/hesburghsite_spec_helper'
 
 feature 'User Browsing', js: true do
-  scenario 'Test 1: Loads Homepage' do
+  scenario 'Test 1: Loads Homepage', :read_only do
     visit '/'
     within('.signup') do
       expect(page).to have_link('Keep in Touch')
@@ -19,7 +19,7 @@ feature 'User Browsing', js: true do
     expect(page).to have_selector('#timeline')
   end
 
-  scenario 'Test 2: Visit Story Index' do
+  scenario 'Test 2: Visit Story Index', :read_only do
     page.driver.browser.js_errors = false # JS erors on some of the pages
     visit '/'
     click_on('Story Index')
@@ -41,7 +41,7 @@ feature 'User Browsing', js: true do
     end
   end
 
-  scenario 'Test 3: Click on chapter on Story Index page' do
+  scenario 'Test 3: Click on chapter on Story Index page', :read_only do
     page.driver.browser.js_errors = false
     visit '/'
     click_on('Story Index')
@@ -71,7 +71,7 @@ feature 'User Browsing', js: true do
         end
     end
   end
-  scenario 'Test 4: Click specific story on Story Index page' do
+  scenario 'Test 4: Click specific story on Story Index page', :read_only do
     page.driver.browser.js_errors = false
     visit '/'
     click_on('Story Index')
@@ -97,7 +97,7 @@ feature 'User Browsing', js: true do
       expect(page).to have_link('Document Gallery')
     end
   end
-  scenario 'Test 5: Visit the Media Gallery page' do
+  scenario 'Test 5: Visit the Media Gallery page', :read_only do
     page.driver.browser.js_errors = false
     visit '/'
     click_on('Media Gallery')
@@ -117,14 +117,14 @@ feature 'User Browsing', js: true do
       expect(page).to have_css('audio')
     end
   end
-  scenario 'Test 6: Click on Speeches link' do
+  scenario 'Test 6: Click on Speeches link', :read_only do
     visit '/'
     new_window = window_opened_by {click_on('Speeches')}
     within_window new_window do
       expect(current_url).to eq('http://archives.nd.edu/Hesburgh/speeches.htm')
     end
   end
-  scenario 'Test 7: Visit the Further Research page' do
+  scenario 'Test 7: Visit the Further Research page', :read_only do
     visit '/'
     new_window = window_opened_by {click_on('Further Research')}
     within_window new_window do
@@ -133,7 +133,7 @@ feature 'User Browsing', js: true do
       end
     end
   end
-  scenario 'Test 8: Visit the About page' do
+  scenario 'Test 8: Visit the About page', :read_only do
     page.driver.browser.js_errors = false
     visit '/'
     click_on('About')
@@ -151,13 +151,12 @@ feature 'User Browsing', js: true do
     expect(page).to have_content('About Father Hesburgh')
     expect(page).to have_content('Leilani Briel')
   end
-  scenario 'Test 9: Click on Keep in Touch tab' do
+  scenario 'Test 9: Click on Keep in Touch tab', :read_only do
     visit '/'
     click_on('Keep in Touch')
     expect(page).to have_selector('#mailinglist', visible: true)
     within('#mc_embed_signup_scroll') do
       expect(page).to have_css('label', count: 3)
-  
       expect(page).to have_css('input', id: 'mce-EMAIL')
       expect(page).to have_css('input', id: 'mce-FNAME')
       expect(page).to have_css('input', id: 'mce-LNAME')

--- a/spec/honeycomb/functional/func_honeycomb_spec.rb
+++ b/spec/honeycomb/functional/func_honeycomb_spec.rb
@@ -3,7 +3,7 @@ require 'osf/osf_spec_helper'
 
 feature 'Institutional Login', js: true do
   let(:login_page) { LoginPage.new(current_logger, account_details_updated: false) }
-  scenario 'Sign in by institution (Notre Dame)', :validates_login do
+  scenario 'Sign in by institution (Notre Dame)', :read_only, :validates_login do
     visit '/'
     login_page.completeLogin
     expect(page).to have_selector('.glyphicon-log-out')

--- a/spec/inquisition/functional/func_inquisition_spec.rb
+++ b/spec/inquisition/functional/func_inquisition_spec.rb
@@ -2,7 +2,7 @@
 
 require 'inquisition/inquisition_spec_helper'
 
-feature 'User Browsing', js: true do
+feature 'User Browsing', js: true , :read_only do
   scenario 'Load Homepage', :read_only, :smoke_test do
     page.driver.browser.js_errors = false
     visit '/'

--- a/spec/microfilms/functional/func_microfilms_spec.rb
+++ b/spec/microfilms/functional/func_microfilms_spec.rb
@@ -3,7 +3,7 @@
 require 'microfilms/microfilms_spec_helper'
 
 feature 'User Browsing', js: true do
-  scenario 'Loads Home Page', :smoke_test do
+  scenario 'Loads Home Page', :smoke_test, :read_only do
     page.driver.browser.js_errors = false
     visit '/'
     home_page = Microfilms::Pages::HomePage.new

--- a/spec/microfilms/functional/func_microfilms_spec.rb
+++ b/spec/microfilms/functional/func_microfilms_spec.rb
@@ -10,7 +10,7 @@ feature 'User Browsing', js: true do
     expect(home_page).to be_on_page
   end
 
-  scenario 'Test facet navigation' do
+  scenario 'Test facet navigation', :read_only do
     page.driver.browser.js_errors = false
     visit '/'
     within('.facets') do

--- a/spec/monarchLibguides/integration/int_monarchLibguides_spec.rb
+++ b/spec/monarchLibguides/integration/int_monarchLibguides_spec.rb
@@ -3,7 +3,7 @@ require 'monarchLibguides/monarchLibguides_spec_helper'
 
 feature 'monarchLibguides API tests' do
   SwaggerHandler.operations(for_file_path: __FILE__).each do |operation|
-    scenario "calls #{operation.verb} #{operation.path}" do
+    scenario "calls #{operation.verb} #{operation.path}", :read_only do
       schema = RequestBuilder.new(current_logger, operation)
       result = schema.send_via_operation_verb
       current_response = ResponseValidator.new(operation, result)

--- a/spec/osf/functional/func_osf_spec.rb
+++ b/spec/osf/functional/func_osf_spec.rb
@@ -3,7 +3,7 @@ require 'osf/osf_spec_helper'
 
 feature 'Institutional Login', js: true do
   let(:login_page) { LoginPage.new(current_logger, account_details_updated: false) }
-  scenario 'Sign in by institution (Notre Dame)' do
+  scenario 'Sign in by institution (Notre Dame)', :read_only do
     visit '/'
     click_on('Sign In')
     page.has_selector?('#alternative-institution')

--- a/spec/primo/functional/func_primo_spec.rb
+++ b/spec/primo/functional/func_primo_spec.rb
@@ -3,14 +3,14 @@
 require 'primo/primo_spec_helper'
 
 feature 'User browsing', js: true do
-  scenario 'Load homepage', :smoke_test do
+  scenario 'Load homepage', :smoke_test, :read_only do
     page.driver.browser.js_errors = false
     visit '/'
     home_page = Primo::Pages::HomePage.new
     expect(home_page).to be_on_page
   end
 
-  scenario 'User searches OneSearch' do
+  scenario 'User searches OneSearch', :read_only do
     page.driver.browser.js_errors = false
     visit '/'
     home_page = Primo::Pages::HomePage.new
@@ -23,7 +23,7 @@ feature 'User browsing', js: true do
     expect(search_results_page).to be_on_page
   end
 
-  scenario 'User searches NDCatalog' do
+  scenario 'User searches NDCatalog', :read_only do
     page.driver.browser.js_errors = false
     visit '/'
     home_page = Primo::Pages::HomePage.new

--- a/spec/rbsc/functional/func_rbsc_spec.rb
+++ b/spec/rbsc/functional/func_rbsc_spec.rb
@@ -2,7 +2,7 @@
 require 'rbsc/rbsc_spec_helper'
 
 feature 'User Browsing', js: true do
-  scenario 'Load homepage', :smoke_test do
+  scenario 'Load homepage', :smoke_test, :read_only do
     # Setting js_error false will suppress errors coming back from the site and let the tests finish
     page.driver.browser.js_errors = false
     visit '/'

--- a/spec/recommendationEngine/integration/int_recommendationEngine_spec.rb
+++ b/spec/recommendationEngine/integration/int_recommendationEngine_spec.rb
@@ -4,7 +4,7 @@ require 'recommendationEngine/recommendationEngine_spec_helper'
 
 feature 'Recommendation Engine API test' do
   SwaggerHandler.operations(for_file_path: __FILE__).each do |operation|
-    scenario "calls #{operation.verb} #{operation.path}" do
+    scenario "calls #{operation.verb} #{operation.path}", :read_only do
       schema = RequestBuilder.new(current_logger, operation)
       result = schema.send_via_operation_verb
       current_response = ResponseValidator.new(operation, result)

--- a/spec/remix/functional/func_remix_spec.rb
+++ b/spec/remix/functional/func_remix_spec.rb
@@ -3,7 +3,7 @@ require 'remix/remix_spec_helper'
 
 feature 'Institutional Login', js: true do
   let(:login_page) { LoginPage.new(current_logger, account_details_updated: false) }
-  scenario 'Sign in by institution (Notre Dame)', :validates_login, :smoke_test do
+  scenario 'Sign in by institution (Notre Dame)', :validates_login, :smoke_test , :read_only do
     visit '/Shibboleth.sso/Login?target=https%3A%2F%2Fremix.nd.edu%2F%3Fq%3Dshib_login%2Fnode%2F27'
     login_page.completeLogin
     expect(page).to have_selector('.header__site-link')

--- a/spec/sipity/functional/func_sipity_spec.rb
+++ b/spec/sipity/functional/func_sipity_spec.rb
@@ -3,7 +3,7 @@ require 'sipity/sipity_spec_helper'
 
 feature 'First Time User', js: true do
   let(:casLogin) { LoginPage.new(current_logger, terms_of_service_accepted: false) }
-  scenario 'FIRST TIME User Sign In', :validates_login, js: true  do
+  scenario 'FIRST TIME User Sign In', :validates_login, :read_only, js: true  do
     sign_in
     welcome_page = Sipity::Pages::ETDWelcomePage.new
     expect(welcome_page).to be_on_page
@@ -15,36 +15,36 @@ end
 
 feature 'User Browsing', js: true do
   let(:casLogin) { LoginPage.new(current_logger, terms_of_service_accepted: true) }
-  scenario 'Visit Homepage', :smoke_test do
+  scenario 'Visit Homepage', :smoke_test, :read_only do
     visit_home
   end
 
-  scenario 'RETURN User Sign In', :validates_login, js: true do
+  scenario 'RETURN User Sign In', :validates_login, :read_only , js: true do
     returning_user_sign_in
   end
 
-  scenario 'View Dashboard', js: true do
+  scenario 'View Dashboard', :read_only, js: true do
     returning_user_sign_in
     find_link("Dashboard").click
     dashboard = Sipity::Pages::Dashboard.new
     expect(dashboard).to be_on_page
   end
 
-  scenario 'Start an ETD Submission', js: true do
+  scenario 'Start an ETD Submission', :read_only, js: true do
     returning_user_sign_in
     find_link("Start an ETD Submission").click
     submission_page = Sipity::Pages::ETDSubmissionPage.new
     expect(submission_page).to be_on_page
   end
 
-  scenario 'View Submitted ETDs', js: true do
+  scenario 'View Submitted ETDs', :read_only, js: true do
     returning_user_sign_in
     find_link("View Submitted ETDs").click
     submission_page = Sipity::Pages::SubmittedETDPage.new
     expect(submission_page).to be_on_page
   end
 
-  scenario 'View New Deposit Page', js: true do
+  scenario 'View New Deposit Page', :read_only, js: true do
     returning_user_sign_in
     find_link("Dashboard").click
     dashboard = Sipity::Pages::Dashboard.new
@@ -54,7 +54,7 @@ feature 'User Browsing', js: true do
     expect(new_deposit_page).to be_on_page
   end
 
-  scenario 'Sign Out', js: true do
+  scenario 'Sign Out', :read_only, js: true do
     returning_user_sign_in
     find_link("Sign out").click
     expect(casLogin).to be_on_page

--- a/spec/solr/functional/func_solr_spec.rb
+++ b/spec/solr/functional/func_solr_spec.rb
@@ -4,17 +4,17 @@ require 'solr/solr_spec_helper'
 # Using the SOLR Ping API to check status of SOLR
 # https://lucene.apache.org/solr/guide/6_6/ping.html#api-examples
 feature 'Ping SOLR status', js: true do
-  scenario 'For "curate" core', :smoke_test do
+  scenario 'For "curate" core', :smoke_test, :read_only do
     visit '/solr/curate/admin/ping?wt=ruby'
     expect(eval(page.text).fetch('status')).to eq('OK')
   end
 
-  scenario 'For "inquisition" core', :smoke_test do
+  scenario 'For "inquisition" core', :smoke_test, :read_only do
     visit '/solr/inquisition/admin/ping?wt=ruby'
     expect(eval(page.text).fetch('status')).to eq('OK')
   end
 
-  scenario 'For "medieval_micro" core', :smoke_test do
+  scenario 'For "medieval_micro" core', :smoke_test, :read_only do
     visit '/solr/medieval_micro/admin/ping?wt=ruby'
     expect(eval(page.text).fetch('status')).to eq('OK')
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,6 +38,7 @@ RSpec.configure do |config|
   # as it helps identify temporal couplings
   config.order = :random
   Kernel.srand config.seed
+  SpecFilterManager.set_default_filters(config: config)
 
   config.before(:suite) do |rspec_suite|
     @current_logger = Bunyan.start(example: rspec_suite, config: ENV, test_handler: self)

--- a/spec/spec_support/spec_filter_manager.rb
+++ b/spec/spec_support/spec_filter_manager.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# This module will provide spec filtering capabilities to the framework
+# based on whether value of ENVIRONMENT variable
+module SpecFilterManager
+  # * when running against production:
+  #     * only runs specs with rspec tag 'read_only'
+  #     * EXCLUDE specs with rspec tag 'nonprod_only'
+  # * If a scenario has both these tags, then Rspec prioritizes exclusion
+  # @example The following scenario will not run
+  # scenario 'Loads Home Page',:read_only, :nonprod_only do
+  #   visit '/'
+  # end
+  def self.set_default_filters(config:)
+    @example_variable = BunyanVariableExtractor.call(path: config.files_to_run[0], config: ENV)
+    if environment_under_test_is_prod?
+      puts "'ENVIRONMENT' categorized as 'production', running only filtered specs"
+      RSpec.configure do |c|
+        c.filter_run_including :read_only
+        c.filter_run_excluding :nonprod_only
+      end
+    elsif environment_under_test_is_nonprod?
+      puts "'ENVIRONMENT' categorized as 'non-production', no filters, running all specs"
+    else
+      # I don't want to assume anything based on regex patterns when 'ENVIRONMENT' is a URL
+      # Especially in cases such as that of library website when the URLs are cloudfront URLs
+      # I'm enforcing an additional input from user to determine if its a production or non_production endpoint
+      puts "Can't categorize 'ENVIRONMENT' as either 'production' or 'non-production', excluding all specs"
+      puts "If you're providing a url as value for 'ENVIRONMENT',"
+      puts "Please retry with an additional input variable 'ENVIRONMENT_CATEGORY'"
+      puts "Value of 'ENVIRONMENT_CATEGORY' should be one of these:"
+      puts "['local', 'dev', 'test', 'prep', 'pprd', 'staging', 'staging6', 'staging8','staging9', 'prod']"
+      # Using a random string as argument to filter_run_including method will skip all tests
+      RSpec.configure do |c|
+        c.filter_run_including (generate_random_string.to_sym)
+      end
+    end
+  end
+
+  def self.environment_under_test_is_prod?
+    possible_production_keys = ['prod']
+    (possible_production_keys.include? @example_variable.environment_under_test) ||
+      (possible_production_keys.include? ENV['ENVIRONMENT_CATEGORY'])
+  end
+
+  def self.environment_under_test_is_nonprod?
+    possible_non_production_keys = ['local', 'dev', 'test', 'prep', 'pprd', 'staging', 'staging6', 'staging8','staging9']
+    (possible_non_production_keys.include? @example_variable.environment_under_test) ||
+    (possible_non_production_keys.include? ENV['ENVIRONMENT_CATEGORY'])
+  end
+
+  def self.generate_random_string
+    (0...100).map { (65 + rand(26)).chr }.join
+  end
+end

--- a/spec/usurper/functional/func_usurper_spec.rb
+++ b/spec/usurper/functional/func_usurper_spec.rb
@@ -110,7 +110,7 @@ feature 'User Browsing', js: true do
     end
   end
 
-  scenario 'Chat with Librarian via button' do
+  scenario 'Chat with Librarian via button', :read_only do
     visit '/'
     within('#chat.footer-chat') do
       find('.chat-button').click
@@ -119,7 +119,7 @@ feature 'User Browsing', js: true do
     end
   end
 
-  scenario 'Go to Workshops page' do
+  scenario 'Go to Workshops page', :read_only do
     visit '/'
     find('#services').click
     find_link('Workshops', href: '/workshops').trigger('click')
@@ -130,14 +130,14 @@ feature 'User Browsing', js: true do
     expect(calendar).to be_on_page
   end
 
-  scenario 'Go to Hours Page' do
+  scenario 'Go to Hours Page', :read_only do
     visit '/'
     find_link('Hours', href: '/hours').click
     hours = Usurper::Pages::HoursPage.new
     expect(hours).to be_on_page
   end
 
-  scenario 'Search using OneSearch from HomePage' do
+  scenario 'Search using OneSearch from HomePage', :read_only do
     visit '/'
     page.driver.browser.js_errors = false # Suprressing JS errors from OneSearch site
     find_button('Search').trigger('click')
@@ -146,7 +146,7 @@ feature 'User Browsing', js: true do
     expect(search).to be_on_page
   end
 
-  scenario 'Search using ND Catalog from HomePage' do
+  scenario 'Search using ND Catalog from HomePage', :read_only do
     visit '/'
     find('.current-search').click
     within('.uSearchOptionList') do
@@ -159,7 +159,7 @@ feature 'User Browsing', js: true do
     expect(search).to be_on_page
   end
 
-  scenario 'Search using CurateND from HomePage' do
+  scenario 'Search using CurateND from HomePage', :read_only do
     visit '/'
     find('.current-search').click
     within('.uSearchOptionList') do
@@ -170,7 +170,7 @@ feature 'User Browsing', js: true do
     expect(current_url).to match(/^https:\/\/curate.nd.edu\/catalog./)
   end
 
-  scenario 'Search using Library Website from HomePage' do
+  scenario 'Search using Library Website from HomePage', :read_only do
     visit '/'
     find('.current-search').click
     within('.uSearchOptionList') do
@@ -184,7 +184,7 @@ end
 
 feature 'Logged In User Browsing', js: true do
   let(:login) { LoginPage.new(current_logger) }
-  scenario 'Log In', :validates_login do
+  scenario 'Log In', :read_only, :validates_login do
     visit '/'
     click_on('Login')
     login.completeLogin
@@ -192,7 +192,7 @@ feature 'Logged In User Browsing', js: true do
     expect(logged_in_home).to be_on_page
   end
 
-  scenario 'View Checked Out/Pending Items' do
+  scenario 'View Checked Out/Pending Items', :read_only do
     visit '/'
     click_on('Login')
     login.completeLogin
@@ -201,7 +201,7 @@ feature 'Logged In User Browsing', js: true do
     expect(accountpage).to be_on_page
   end
 
-  scenario 'View Courses/Instructs' do
+  scenario 'View Courses/Instructs', :read_only do
     # Does not run properly do to issues with
     visit '/'
     click_on('Login')

--- a/spec/usurperContent/integration/int_usurperContent_spec.rb
+++ b/spec/usurperContent/integration/int_usurperContent_spec.rb
@@ -3,7 +3,7 @@ require 'usurperContent/usurperContent_spec_helper'
 
 feature 'API tests for Usurper Content API' do
   SwaggerHandler.operations(for_file_path: __FILE__).each do |operation|
-    scenario "calls #{operation.verb} #{operation.path}" do
+    scenario "calls #{operation.verb} #{operation.path}", :read_only do
       schema = RequestBuilder.new(current_logger, operation)
       result = schema.send_via_operation_verb
       current_response = ResponseValidator.new(operation, result)

--- a/spec/vatican/functional/func_vatican_spec.rb
+++ b/spec/vatican/functional/func_vatican_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require 'vatican/vatican_spec_helper'
-feature "User Browsing", js: true do
+feature "User Browsing", :read_only, js: true do
   scenario 'Load Homepage' do
     page.driver.browser.js_errors = false
     visit '/'
@@ -8,7 +8,7 @@ feature "User Browsing", js: true do
     expect(home_page).to be_on_page
   end
 
-  scenario 'Go to "How To Use Database" page' do
+  scenario 'Go to "How To Use Database" page', :read_only do
     page.driver.browser.js_errors = false
     visit '/'
     click_on('How To Use the Database')
@@ -16,7 +16,7 @@ feature "User Browsing", js: true do
     expect(instructions_page).to be_on_page
   end
 
-  scenario 'Load "Search the Database" page' do
+  scenario 'Load "Search the Database" page', :read_only do
     page.driver.browser.js_errors = false
     visit '/'
     click_on("Search The Database")
@@ -24,7 +24,7 @@ feature "User Browsing", js: true do
     expect(search_page).to be_on_page
   end
 
-  scenario 'Validate navigation menu on search page' do
+  scenario 'Validate navigation menu on search page', :read_only do
     page.driver.browser.js_errors = false
     visit '/'
     click_on("Search The Database")
@@ -35,7 +35,7 @@ feature "User Browsing", js: true do
     end
   end
 
-  scenario 'Check a box in "Search By Topic"' do
+  scenario 'Check a box in "Search By Topic"', :read_only do
     page.driver.browser.js_errors = false
     visit '/'
     click_on("Search The Database")
@@ -45,7 +45,7 @@ feature "User Browsing", js: true do
     expect(page).to have_content("Catholic Social Teaching")
   end
 
-  scenario 'Clear Selected Topic' do
+  scenario 'Clear Selected Topic', :read_only do
     page.driver.browser.js_errors = false
     visit '/'
     click_on("Search The Database")
@@ -59,7 +59,7 @@ feature "User Browsing", js: true do
     expect(page).to have_no_content("Catholic Social Teaching")
   end
 
-  scenario 'Search Results Divided into Columns' do
+  scenario 'Search Results Divided into Columns', :read_only do
     page.driver.browser.js_errors = false
     visit '/'
     click_on("Search The Database")
@@ -75,7 +75,7 @@ feature "User Browsing", js: true do
     expect(page).to have_content("International Human Rights Law")
   end
 
-  scenario 'Access Entire Document' do
+  scenario 'Access Entire Document', :read_only do
     page.driver.browser.js_errors = false
     visit '/'
     click_on("Search The Database")
@@ -95,7 +95,7 @@ feature "User Browsing", js: true do
     expect(page).to have_content("Topics in Document")
   end
 
-  scenario 'Sort Newest To Oldest' do
+  scenario 'Sort Newest To Oldest', :read_only do
     page.driver.browser.js_errors = false
     visit '/'
     click_on("Search The Database")

--- a/spec/viceroy/integration/int_viceroy_spec.rb
+++ b/spec/viceroy/integration/int_viceroy_spec.rb
@@ -3,7 +3,7 @@ require 'viceroy/viceroy_spec_helper'
 
 feature 'Viceroy API test' do
   SwaggerHandler.operations(for_file_path: __FILE__).each do |operation|
-    scenario "calls #{operation.verb} #{operation.path}" do
+    scenario "calls #{operation.verb} #{operation.path}", :read_only do
       schema = RequestBuilder.new(current_logger, operation)
       result = schema.send_via_operation_verb
       current_response = ResponseValidator.new(operation, result)

--- a/spec/xur/functional/func_xur_spec.rb
+++ b/spec/xur/functional/func_xur_spec.rb
@@ -3,7 +3,7 @@
 require 'xur/xur_spec_helper'
 
 feature 'Load home page', js: true do
-  scenario 'Check version', :smoke_test do
+  scenario 'Check version', :read_only, :smoke_test do
     visit '/'
     home_page = XUR::Pages::HomePage.new
     expect(home_page).to be_on_page


### PR DESCRIPTION
## Adds SpecFilterManager module

2a0ab09a1f4d3a72c9f3abf4ecc908d2971c48d0

* Adds SpecFilterManager module
 This module will provide spec filtering capabilities to the framework
 based on value of ENVIRONMENT variable.
* Adds 'set_default_filters' method to the module
 If the ENVIRONMENT variable is a valid key in the spec's config file
 then it proceeds to determine if its a 'production' or 'non_production'
 based on these values:
 possible_production_keys = ['prod']
 possible_non_production_keys = ['local', 'dev', 'test', 'prep', 'pprd', 'staging', 'staging6', 'staging8','staging9']
* For 'production' endpoints, this method configures Rspec to include
only scenarios that are tagged as 'read_only' and explicitly excludes
scenarios tagged as 'nonprod_only' (to handle scenarios that have both these tags)
In that case Rspec will not run the scenario
 @example The following scenario will not run:
 ```ruby
 scenario 'Loads Home Page',:read_only, :nonprod_only do
   visit '/'
 end
 ```
 * I'm also explicitly requiring the user to input 'ENVIRONMENT_CATEGORY'
 in case they run the spec with the 'ENVIRONMENT' value as a http URL.
 I'm trying to avoid making any assumptions about whether the URL is
 considered 'production' or 'non_production'. Especially in cases when
 URL like: http://dld625i.cloudfront.net or https://5sm5qzp.execute-api.us-east-1.amazonaws.com/r20180302

## Adding 'read_only' tags to all scenarios

5a75f311cc9cf11896393afd4de8fb0c92f8605a


## Updates 'bin/run_tests' and README file

531234983d150e24b9fd7626090b0b5432a567bd

* Adds support for accepting 'ENVIRONMENT_CATEGORY' variable in 'run_tests'
* Consolidates test running instructions in 'bin/run_tests' to avoid
duplication and inconsistencies

## Pending changes
* Add support for Jenkins to be able to handle these changes. I need this PR to merged before I can test with Jenkins
* Customize Rubocop to enforce tagging of each scenario