### PR TITLE
Library website release r20180316 updates

### DIFF
--- a/spec/usurper/pages/lib_calendar_page.rb
+++ b/spec/usurper/pages/lib_calendar_page.rb
@@ -29,7 +29,7 @@ module Usurper
       end
 
       def correct_url?
-        page.current_url == 'http://nd.libcal.com/calendar/allworkshops/?cid=447&t=m&d=0000-00-00&cal%5B%5D=447'
+        page.current_url == 'http://nd.libcal.com/calendar/allworkshops/?cid=447&t=m&d=0000-00-00&cal=447'
       end
     end
   end

--- a/spec/usurper/pages/reseach_guides_page.rb
+++ b/spec/usurper/pages/reseach_guides_page.rb
@@ -16,9 +16,8 @@ module Usurper
       end
 
       def on_valid_url?
-        #Link to the libcal reserve library spaces page
-        libcal_research_guides = ('http://libguides.library.nd.edu/')
-        current_url == libcal_research_guides
+        # Library guides Homepage redirects to 'By Subject' tab on load
+        current_url == 'http://libguides.library.nd.edu/?b=s'
       end
 
     def correct_content?


### PR DESCRIPTION
## Updates `on_valid_url` method for Libguides page

e3d24dbc5f0d43ace9d339b9d9e1c278a3b34620

There is a new redirect that appends a query parameter on the
Libguides page to default 'By Subject' tab

## Removes special characters from URL for lib calendar page

7930da2850586efc6425af994413d2e111e7f5a1