### PR TITLE
Curate specs, show article page Generalizes `within` scope for attributes field

### DIFF
--- a/spec/curate/pages/show_article.rb
+++ b/spec/curate/pages/show_article.rb
@@ -55,7 +55,7 @@ module Curate
         within("article.abstract.descriptive-text") do
           page.has_selector?("p", minimum: 1)
         end
-        within("table.table.table-striped.document.attributes") do
+        within("table.table.table-striped.attributes") do
           first('p')
         end
       end


### PR DESCRIPTION
## Generalizes `within` scope for attributes field
CSS for different types of content are different:
table.table.table-striped.document.attributes
table.table.table-striped.finding_aid.attributes
table.table.table-striped.dataset.attributes

Any of these types of articles could be picked in the '[Show an Article with many files](https://github.com/ndlib/QA_tests/blob/master/spec/curate/functional/func_curate_spec.rb#L544)' or '[Show an Article](https://github.com/ndlib/QA_tests/blob/master/spec/curate/functional/func_curate_spec.rb#L89)' scenarios.

This change generalizes the `within` scope so that 'valid_page_content?'
method can work for verifying the attributes section of different
types of data.