### PR TITLE
Hp curate spec filters

### DIFF
--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -541,7 +541,7 @@ feature 'Catalog Thumbnail Views:', js: true do
 end
 
 feature 'Browsing attached files' do
-  scenario "Show an Article with many files", :read_only do
+  scenario "Show an Article with many files", :read_only, :nonprod_only do
     visit '/'
     home_page = Curate::Pages::HomePage.new
     expect(home_page).to be_on_page

--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -310,7 +310,7 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     expect(logged_in_home_page).to be_on_page
   end
 
-  scenario "Manage My Works", js: true, :read_only do
+  scenario "Manage My Works", :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin


### PR DESCRIPTION
## Fixes syntax issue, and removes redundant 'js: true'

dab5cc8d6eeec0a4ef9ae87d77f60f5d45d105fc
* Since `js: true` is already there at the feature level, don't need it again at the scenario level
* Even if we do, the correct syntax would be to have `js: true`  after the rspec tags

## Excludes scenario from running in production

df11b68551a0b82166b57dd535e8867bc38b3696
This scenario is dependent on data setup, and we're not going to do test data setup in production. So I'm excluding it from running in production using the [SpecFilterManager](https://github.com/ndlib/QA_tests/blob/master/spec/spec_support/spec_filter_manager.rb#L20)