### PR TITLE
Creates an additional feature testing ORCID

### DIFF
--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -310,7 +310,7 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     expect(logged_in_home_page).to be_on_page
   end
 
-  scenario "Manage My Works", js: true, :read_only do
+  scenario "Manage My Works", :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -472,9 +472,9 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
   end
 end
 
-feature 'Logged in user changing ORCID settings:', js: true do
+feature 'Logged in user changing ORCID settings (Account Details Not Updated):', js: true do
   let(:login_page) { LoginPage.new(current_logger, account_details_updated: false) }
-  scenario "Go to ORCID.org home page", :validates_login, :read_only do
+  scenario "Go to ORCID.org Signin page", :validates_login, :read_only do
     visit '/'
     click_on('Log In')
     login_page.completeLogin
@@ -491,7 +491,31 @@ feature 'Logged in user changing ORCID settings:', js: true do
     find_link('Create or Connect your ORCID iD').trigger('click')
     sleep(1)
     orcid_home_page = Curate::Pages::OrcidHomePage.new
-    expect(orcid_home_page).to be_on_page
+    expect(orcid_home_page).to be_on_page(login_page.account_details_updated)
+  end
+end
+
+feature 'Logged in user changing ORCID settings (Account Details Updated):', js: true do
+  let(:login_page) { LoginPage.new(current_logger, account_details_updated: true) }
+  scenario "Go to ORCID.org registration page", :validates_login, :read_only do
+    visit '/'
+    click_on('Log In')
+    login_page.completeLogin
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
+    expect(logged_in_home_page).to be_on_page
+    logged_in_home_page.openActionsDrawer
+    click_on("My Profile")
+    click_on("Update Personal Information")
+    account_details_page = Curate::Pages::AccountDetailsPage.new
+    expect(account_details_page).to be_on_page
+    find_link('ORCID Settings').trigger('click')
+    sleep(1)
+    orcid_settings_page = Curate::Pages::OrcidSettingsPage.new
+    expect(orcid_settings_page).to be_on_page
+    find_link('Create or Connect your ORCID iD').trigger('click')
+    sleep(1)
+    orcid_home_page = Curate::Pages::OrcidHomePage.new
+    expect(orcid_home_page).to be_on_page(login_page.account_details_updated)
   end
 end
 

--- a/spec/curate/pages/orcid_home_page.rb
+++ b/spec/curate/pages/orcid_home_page.rb
@@ -5,10 +5,10 @@ module Curate
       include Capybara::DSL
       include CapybaraErrorIntel::DSL
 
-      def on_page?
+      def on_page?(account_details_updated)
         on_valid_url? &&
           status_response_ok? &&
-          valid_page_content? &&
+          valid_page_content?(account_details_updated) &&
           valid_uri_parameters?
       end
 
@@ -20,10 +20,18 @@ module Curate
         status_code == 200
       end
 
-      def valid_page_content?
+      def valid_page_content?(account_details_updated)
         page.has_content?("ORCID")
-        page.has_selector?(:link_or_button, "Register")
-        page.has_selector?(:link_or_button, "Sign In")
+        if account_details_updated
+          find('#register-form-password')
+          page.has_selector?(:link_or_button, "Sign In")
+          page.has_selector?(:link_or_button, "Register")
+        else
+          find('#userId.form-control.ng-pristine.ng-untouched.ng-valid.ng-empty')
+          find('#password.form-control')
+          page.has_selector?(:link_or_button, "Register now")
+          page.has_selector?(:link_or_button, "Sign into ORCID")
+        end
       end
 
       def valid_uri_parameters?


### PR DESCRIPTION
* Additional feature tests ORCID page with test users that have AccountDetailUpdated=true
* The on_page? and valid_page_content? methods in the OrcidHomePage class have been modified to take the value of account_details_updated as a parameter so the valid_page_content? method can account for both user types as they are sent to different ORCID pages
* When account_details_updated = false, the scenario tests for the Sign In page
* When account_details_updated = true, the scenario tests for the Registration page