### PR TITLE
Using trigger has been more reliable

### DIFF
--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -127,7 +127,7 @@ feature 'Facet Navigation', js: true do
       expect(page).to have_selector('#ajax-modal', visible: true)
       expect(page).to have_content(facet_name)
       within('#ajax-modal') do
-        find('.close').click
+        find('.close').trigger('click')
       end
       expect(page).not_to have_selector("#ajax-modal", visible: true)
     end


### PR DESCRIPTION
Sometimes the click method doesn't fire actions in Capybara, but wrapping it around trigger method has been more effective. This change addresses that behavior to make the tests more reliable.