### PR TITLE
Add tests for inquisitions error pages

### DIFF
--- a/spec/curate/pages/audio_page.rb
+++ b/spec/curate/pages/audio_page.rb
@@ -3,7 +3,11 @@ module Curate
     class AudioPage
       include Capybara::DSL
       include CapybaraErrorIntel::DSL
-      VerifyNetworkTraffic.exclude_uri_from_network_traffic_validation.push('/assets/ui-bg_highlight-soft_100_eeeeee_1x100.png')
+
+      def initialize
+        VerifyNetworkTraffic.exclude_uri_from_network_traffic_validation.push('/assets/ui-bg_highlight-soft_100_eeeeee_1x100.png')
+      end
+
       def on_page?
           on_valid_url? &&
           status_response_ok? &&

--- a/spec/inquisition/functional/func_inquisition_spec.rb
+++ b/spec/inquisition/functional/func_inquisition_spec.rb
@@ -2,11 +2,78 @@
 
 require 'inquisition/inquisition_spec_helper'
 
-feature 'User Browsing', js: true , :read_only do
+feature 'User Browsing', :read_only, js: true do
   scenario 'Load Homepage', :read_only, :smoke_test do
     page.driver.browser.js_errors = false
     visit '/'
     home_page = Inquisition::Pages::HomePage.new
+    expect(home_page).to be_on_page
+  end
+end
+
+feature 'Error pages', js: true do
+  scenario 'Load custom 404 page', :read_only do
+    page.driver.browser.js_errors = false
+    url = '/404'
+    visit url
+    home_page = Inquisition::Pages::ErrorPage.new(error_code: 404, url: url)
+    expect(home_page).to be_on_page
+  end
+
+  scenario 'Load custom 422 page', :read_only do
+    page.driver.browser.js_errors = false
+    url = '/422'
+    visit url
+    home_page = Inquisition::Pages::ErrorPage.new(error_code: 422, url: url)
+    expect(home_page).to be_on_page
+  end
+
+  scenario 'Load custom 500 page', :read_only do
+    page.driver.browser.js_errors = false
+    url = '/500'
+    visit url
+    home_page = Inquisition::Pages::ErrorPage.new(error_code: 500, url: url)
+    expect(home_page).to be_on_page
+  end
+
+  scenario 'Load a collection that does not exist', :read_only do
+    page.driver.browser.js_errors = false
+    url = '/collections/dne'
+    visit url
+    home_page = Inquisition::Pages::ErrorPage.new(error_code: 404, url: url)
+    expect(home_page).to be_on_page
+  end
+
+  scenario 'Load a download that does not exist', :read_only do
+    page.driver.browser.js_errors = false
+    url = '/downloads/dne'
+    visit url
+    home_page = Inquisition::Pages::ErrorPage.new(error_code: 404, url: url)
+    expect(home_page).to be_on_page
+  end
+
+  # This currently gives a 500
+  xscenario 'Load an item that does not exist', :read_only do
+    page.driver.browser.js_errors = false
+    url = '/items/dne'
+    visit url
+    home_page = Inquisition::Pages::ErrorPage.new(error_code: 404, url: url)
+    expect(home_page).to be_on_page
+  end
+
+  scenario 'Load an invalid route', :read_only do
+    page.driver.browser.js_errors = false
+    url = '/route/dne'
+    visit url
+    home_page = Inquisition::Pages::ErrorPage.new(error_code: 404, url: url)
+    expect(home_page).to be_on_page
+  end
+
+  scenario 'Load a document that cannot be downloaded', :read_only do
+    page.driver.browser.js_errors = false
+    url = '/downloads/RBSC-INQ:COLLECTION'
+    visit url
+    home_page = Inquisition::Pages::ErrorPage.new(error_code: 500, url: url)
     expect(home_page).to be_on_page
   end
 end

--- a/spec/inquisition/inquisition_config.yml
+++ b/spec/inquisition/inquisition_config.yml
@@ -1,2 +1,3 @@
-prep: https://inquisition-prep.library.nd.edu
+local: http://localhost:3000
+prep: https://inquisition-prep.lc.nd.edu
 prod: https://inquisition.library.nd.edu

--- a/spec/inquisition/pages/error_page.rb
+++ b/spec/inquisition/pages/error_page.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'inquisition/inquisition_spec_helper'
+
+module Inquisition
+  module Pages
+    class ErrorPage
+      include Capybara::DSL
+      include CapybaraErrorIntel::DSL
+
+      attr_reader :error_code, :url
+
+      def initialize(error_code:, url:)
+        VerifyNetworkTraffic.exclude_uri_from_network_traffic_validation.push("#{url}")
+        @error_code = error_code
+        @url = url
+      end
+
+      def on_page?
+        status_response_ok? &&
+          has_title? &&
+          on_valid_url?
+      end
+
+      def status_response_ok?
+        status_code == error_code
+      end
+
+      def on_valid_url?
+      current_url == File.join(Capybara.app_host, url)
+      end
+
+      def has_title?
+        within('.dialog') do
+          case error_code
+            when 404
+              has_content?("The page you were looking for doesn't exist.")
+            when 422
+              has_content?("The change you wanted was rejected.")
+            else
+              has_content?("We're sorry, but something went wrong.")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/primo/pages/home_page.rb
+++ b/spec/primo/pages/home_page.rb
@@ -5,7 +5,11 @@ module Primo
     class HomePage
       include Capybara::DSL
       include CapybaraErrorIntel::DSL
-      VerifyNetworkTraffic.exclude_uri_from_network_traffic_validation.push('/PDSMExlibris.css')
+
+      def initialize
+        VerifyNetworkTraffic.exclude_uri_from_network_traffic_validation.push('/PDSMExlibris.css')
+      end
+
       def on_page?
         on_valid_url? &&
           status_response_ok? &&

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -66,5 +66,6 @@ RSpec.configure do |config|
     VerifyNetworkTraffic.report_network_traffic(driver: Capybara.current_session.driver, test_handler: self)
     @current_logger.stop()
     Bunyan.reset_current_logger!
+    VerifyNetworkTraffic.exclude_uri_from_network_traffic_validation.clear
   end
 end

--- a/spec/usurper/pages/reseach_guides_page.rb
+++ b/spec/usurper/pages/reseach_guides_page.rb
@@ -4,8 +4,9 @@ module Usurper
     class ResearchGuidesPage < BasePage
       include Capybara::DSL
       include CapybaraErrorIntel::DSL
-      VerifyNetworkTraffic.exclude_uri_from_network_traffic_validation.push('/svn/loader/run_prettify.js', '/libapps/sites/3767/include/img/jesus.gif')
+
       def initialize
+        VerifyNetworkTraffic.exclude_uri_from_network_traffic_validation.push('/svn/loader/run_prettify.js', '/libapps/sites/3767/include/img/jesus.gif')
         last_opened_window = page.driver.browser.window_handles.last
         page.driver.browser.switch_to_window(last_opened_window)
       end


### PR DESCRIPTION
## QA-46, DLTP-1345: Add tests for inquisitions error pages

a357ea120c3cba24c116b37ed48e2882da30a4cf

- Added an ErrorPage spec helper and added a few known scenarios where the app should render these custom error pages
- Changed spec_helper to clear the VerifyNetworkTraffic.exclude_uri_from_network_traffic_validation on tear down of each test. Adding urls to this list will now need to be done as part of each scenario that cares about it, not just when the modules are loaded. In all cases I found, we're using Page helpers to construct this list, so added it to their initialize methods. Currently this will impact primo, inquisition, curate, and usurper tests.
- This does not cover pages that should load with 200