### PR TITLE
Creates Rubocop linter for checking the RSpec tags of each scenario in a spec file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
-require: rubocop-rspec
+require:
+  - rubocop-rspec
+  - ./linter/rspec_tags/check_tags.rb
 inherit_from: .rubocop_todo.yml
 
 AllCops:
@@ -12,6 +14,9 @@ AllCops:
     - 'script/**/*'
     - 'spec/test_app_templates/**/*'
     - 'vendor/**/*'
+
+RSpecTags/CheckTags:
+  Enabled: true
 
 Lint/ImplicitStringConcatenation:
   Exclude:

--- a/linter/rspec_tags/check_tags.rb
+++ b/linter/rspec_tags/check_tags.rb
@@ -1,0 +1,51 @@
+module RuboCop
+  module Cop
+    module RSpecTags
+      class CheckTags < RuboCop::Cop::Cop
+        # This cop checks for :nonprod_only and :read_only RSpec tags on scenario lines.
+        # Each scenario must have at least one of these tags to discern which scenarios
+        # should be run on prod which ones should not be run on prod.
+        #
+        # @example
+        #    # bad
+        #    scenario "jello" do
+        #
+        # @example
+        #    # good
+        #    scenario "jello", :read_only do
+        #
+        # @example
+        #    # good
+        #    scenario "jello", :nonprod_only do
+        MSG = 'All scenarios must either have a :nonprod_only or a :read_only tag.'.freeze
+
+        def on_block(node)
+          node.each_descendant(:send) do |send_node|
+            method = send_node.method_name
+            next unless is_scenario?(method)
+
+            opts = send_node.child_nodes
+            add_offense(send_node, :expression, format(MSG, send_node.type)) unless has_tags?(opts)
+          end
+        end
+
+        def method_name(node)
+          node.child_nodes[1]
+        end
+
+        def is_scenario?(method)
+          method == :scenario
+        end
+
+        def has_tags?(opts)
+          opts.each do |child|
+            if child.type == :sym && (child.children[0] == :read_only || child.children[0] == :nonprod_only)
+              return true
+            end
+          end
+          return false
+        end
+      end
+    end
+  end
+end

--- a/linter/rspec_tags/check_tags.rb
+++ b/linter/rspec_tags/check_tags.rb
@@ -21,7 +21,7 @@ module RuboCop
         # @example
         #    # good
         #    scenario "jello", :nonprod_only do
-        MSG = 'All scenarios must either have a :nonprod_only or a :read_only tag.'.freeze
+        MSG = 'All scenarios must either have a :nonprod_only or a :read_only tag. Further details see: https://github.com/ndlib/QA_tests#tagging'.freeze
 
         def on_block(node)
           node.each_descendant(:send) do |send_node|

--- a/linter/rspec_tags/check_tags.rb
+++ b/linter/rspec_tags/check_tags.rb
@@ -1,3 +1,7 @@
+# @see https://downey.io/blog/writing-rubocop-linters-for-database-migrations/ for background in creating
+# and implementing custom Rubocop linters
+#
+# @see http://www.rubydoc.info/gems/rubocop/RuboCop/AST to learn about methods for using Rubocop Node Pattern
 module RuboCop
   module Cop
     module RSpecTags


### PR DESCRIPTION
* As each scenario must have a :read_only or a :nonprod_only tag to specify whether or not the scenario should be run on prod configuration, this linter creates an offense whenever a scenario does not have one of these tags

* Screenshot of offense below
![screen shot 2018-04-13 at 11 20 51 am](https://user-images.githubusercontent.com/28707806/38744715-87155f70-3f10-11e8-9fba-58d0b4e3ee10.png)
