### PR TITLE
Suppressess js errors on visit page

### DIFF
--- a/spec/contentful/integration/int_contentful_spec.rb
+++ b/spec/contentful/integration/int_contentful_spec.rb
@@ -12,6 +12,7 @@ feature 'Tests for Contentful entries and webhook integrations' do
       expect(entry).not_to be_published
       # Preview the entry just created using Content Preview API
       entry.make_previewable!
+      page.driver.browser.js_errors = false
       visit "/#{entry.slug}?preview=true"
       page_entry_preview = ContentfulTests::Pages::PageEntryPreview.new(contentful_entry: entry)
       expect(page_entry_preview).to be_on_page
@@ -42,6 +43,7 @@ feature 'Tests for Contentful entries and webhook integrations' do
       # At this point the event entry should have been updated in contentful, so we need to refresh it
       entry.refresh_entry
       entry.make_previewable!
+      page.driver.browser.js_errors = false
       visit "/event/#{entry.slug}?preview=true"
       event_entry_preview = ContentfulTests::Pages::EventEntryPreview.new(contentful_entry: entry)
       expect(event_entry_preview).to be_on_page

--- a/spec/usurper/functional/func_usurper_spec.rb
+++ b/spec/usurper/functional/func_usurper_spec.rb
@@ -43,6 +43,7 @@ feature 'User Browsing', js: true do
     visit '/'
     within('.uNavigation') do
       find_by_id('services').trigger('click')
+      page.driver.browser.js_errors = false
       click_on('Reserve a Meeting or Event Space')
     end
     room_reservation_services_tab = Usurper::Pages::RoomReservationServicesTabPage.new
@@ -61,6 +62,7 @@ feature 'User Browsing', js: true do
   scenario 'Technology Lending Button', :read_only, :smoke_test do
     visit '/'
     within('.services.hservices') do
+      page.driver.browser.js_errors = false
       find_link(title: 'Technology Lending').trigger('click')
     end
     technology_lending = Usurper::Pages::TechnologyLendingPage.new


### PR DESCRIPTION
Hotjar error reported by Poltergeist but works fine on Chrome:
```error
"class": "Capybara::Poltergeist::JavascriptError",
"message": "One or more errors were raised in the Javascript code on the
 page. If you don't care about these errors, you can ignore them by
  setting js_errors: false in your Poltergeist configuration
  (see documentation for details).\n\nTypeError: undefined is not an
  object (evaluating 'hj.json.parse')\nTypeError: undefined is not an
  object (evaluating 'hj.json.parse')\n    at
  https://script.hotjar.com/modules-5656fcbdd6d51afbdc19cd90486f0c7d.js:8 in onload"
```