### PR TITLE
Refactors curate login scenarios with account_details_updated: false

### DIFF
--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -201,8 +201,8 @@ feature 'Logged In User (Account details NOT updated) Browsing', js: true do
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.open_actions_drawer
     click_on("My Profile")
-    account_details_page = Curate::Pages::AccountDetailsPage.new
-    expect(account_details_page).to be_on_page
+    my_profile_page = Curate::Pages::MyProfilePage.new
+    expect(my_profile_page).to be_on_page
   end
 
   scenario "Visit Deposit New Article page", :read_only do
@@ -594,8 +594,9 @@ feature 'Logged in user changing ORCID settings (Account Details Not Updated):',
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.open_actions_drawer
     click_on("My Profile")
-    account_details_page = Curate::Pages::AccountDetailsPage.new
-    expect(account_details_page).to be_on_page
+    my_profile_page = Curate::Pages::MyProfilePage.new
+    expect(my_profile_page).to be_on_page
+    find_link('Add a Section to my Profile').trigger('click')
     find_link('ORCID Settings').trigger('click')
     sleep(1)
     orcid_settings_page = Curate::Pages::OrcidSettingsPage.new


### PR DESCRIPTION
* Due to [change in Curate which creates a Person/Profile for new users without account details updated](https://github.com/ndlib/curate_nd/pull/687/files/68045e8c4b08c54d81c000b2103ff49fe3d72e89#diff-55c5b7aecfb519d0e4880eaf2788eb6e), the My Profile ribbon link for these types of users points to the My Profile page instead of to the Update Account Details page
  * Thus, scenarios involving this use case needed to be refactored to account for this change.
