### PR TITLE
Excludes spec/solr/**/* from the Security/Eval cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,7 +53,8 @@ Metrics/ModuleLength:
   Max: 200
 
 Security/Eval:
-  Enabled: false
+  Exclude:
+    - 'spec/solr/**/*'
 
 Style/AccessorMethodName:
   Enabled: false


### PR DESCRIPTION
* As the use of eval in the SOLR spec is uniquely safe due to the SOLR Ruby response format, eval is not a security risk in this spec
  * So, the spec will be excluded form the Security/Eval rubocop so that an irrelevant offense is not thrown
* As the eval method is not safe to use for other cases, the cop is not disabled completely and will still scan all other files