### PR TITLE
Adds specs for curate DOI features

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,7 +59,7 @@ Security/Eval:
 Style/AccessorMethodName:
   Enabled: false
 
-Style/IndentationConsistency:
+Layout/IndentationConsistency:
   EnforcedStyle: rails
 
 Style/CollectionMethods:

--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -451,6 +451,33 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     expect(thesis_page).to be_on_page
   end
 
+  scenario "Creates DOI for a new image", :nonprod_only do
+    visit '/'
+    click_on('Log In')
+    login_page.complete_login
+    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
+    expect(logged_in_home_page).to be_on_page
+    logged_in_home_page.open_add_content_drawer
+    click_on("New Image")
+    image_page = Curate::Pages::ImagePage.new
+    expect(image_page).to be_on_page
+    image_page.create_temp_image(access_rights: 'ndu', assign_doi: 'mint-doi')
+    show_article = Curate::Pages::ShowArticlePage.new(title: 'foo')
+    expect(show_article).to be_new_doi_minted_article
+    # Giving some wait time for the server to mint DOI
+    sleep(3)
+    page.refresh
+    expect(show_article).to have_doi
+    find_link('Edit').click
+    edit_article = Curate::Pages::EditWorkPage.new
+    expect(edit_article).to be_on_page
+    expect(edit_article).to have_editable_doi
+    find('.btn.btn-primary.require-contributor-agreement').click
+    accept_prompt do
+      find_link('Delete').click
+    end
+  end
+
   scenario "Log out", :read_only do
     visit '/'
     click_on('Log In')

--- a/spec/curate/pages/edit_work_page.rb
+++ b/spec/curate/pages/edit_work_page.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Curate
+  module Pages
+    class EditWorkPage
+      include Capybara::DSL
+      include CapybaraErrorIntel::DSL
+
+      def on_page?
+        on_valid_url? &&
+          valid_page_content?
+      end
+
+      def on_valid_url?
+        current_url.include? 'edit'
+      end
+
+      def valid_page_content?
+        has_content?("Manage Your Work")
+      end
+
+      def has_editable_doi?
+        within('#doi') do
+          has_content?('Digital Object Identifier')
+          find_link(href: /http.*:\/\/.*doi.org\/doi:.*\/.*/)
+        end
+        # Checks if an editable text box exists
+        find('#image_doi')
+      end
+    end
+  end
+end

--- a/spec/curate/pages/image_page.rb
+++ b/spec/curate/pages/image_page.rb
@@ -33,7 +33,7 @@ module Curate
         has_css?("div.control-group.text.optional.image_description")
       end
 
-      def create_temp_image(access_rights: nil, embargo_date: true)
+      def create_temp_image(access_rights: nil, embargo_date: true, assign_doi: nil)
         fill_in(id: "image_title", with: "foo")
         fill_in(id: "image_creator", with: "foo")
         within('#set-access-controls') do
@@ -48,6 +48,22 @@ module Curate
             choose(id: 'visbility_open')
           end
         end
+        # 'no-doi' implies 'Use an existing DOI for this item'
+        # 'mint-doi' implies 'Create a DOI for this item'
+        # 'image_doi_assignment_strategy_not_now' implies 'Leave the DOI field blank.' This is DEFAULT
+        within('#set-doi') do
+          case assign_doi
+          when 'no-doi'
+            choose(id: 'no-doi')
+          when 'mint-doi'
+            choose(id: 'mint-doi')
+            # 'Publisher' is a required field, and so the image won't be saved yet
+            on_valid_url?
+          else
+            choose(id: 'image_doi_assignment_strategy_not_now')
+          end
+        end
+        fill_in(id: 'publisher', with: 'foo')
         find('#accept_contributor_agreement').click
         find('.btn.btn-primary.require-contributor-agreement').click
       end

--- a/spec/curate/pages/show_article.rb
+++ b/spec/curate/pages/show_article.rb
@@ -51,6 +51,22 @@ module Curate
           first('p')
         end
       end
+
+      def new_doi_minted_article?
+        on_valid_url?
+        has_content?('Your DOI for your work is being requested. It may take a few minutes to generate.')
+        has_content?(@article_title)
+        has_no_content?('Digital Object Identifier')
+        within("table.table.table-striped.attributes") do
+          first('p')
+        end
+      end
+
+      def has_doi?
+        has_content?('Digital Object Identifier')
+        on_valid_url?
+        find_link(href: /http.*:\/\/.*doi.org\/doi:.*\/.*/)
+      end
     end
   end
 end


### PR DESCRIPTION
## Command to run these new specs
```console
ENVIRONMENT=pprd CHROME_HEADLESS=true SKIP_CLOUDWATCH=true RUNNING_ON_LOCAL_DEV=true bin/run_tests spec/curate/functional/func_curate_spec.rb:454
```

## Adds specs for dltp-1444

5ac296640b1d2ed37603aa511ab06950541e9658


## Updates create_temp_image method with doi asserts

15e727d30469212563fa0d3b4581b75697cbed68

* Adds an argument to handle doi radio button selection
* Adds a block of assertions with a case statement
* 'Publisher' is requireed field that needs to be filled in when
minting new doi.

## Adds doi assertion methods for show article page

d7294ecebc10244cbc35bdb72ea58a5f237c6b99

* Adds `new_doi_minted_article?` method which asserts the landing page
when a new article is created
* Adds `has_doi?` method that asserts the page once the server has
finished minting a doi

## Adds a Edit work page

45635d7d0c289a283edd8536f5ea2d0be746469c

* These are the assertions that will be made when a user clicks
'Edit' on an article

## Fixes rubocop complains

681d00a2abeb1f671e5628afdee172ddc1989908

Rubocop complains of namespace issue, this fixes it
```warning
Style/IndentationConsistency has the wrong namespace - should be Layout
```