### PR TITLE
Cutting over usurper specs to chrome headless

### DIFF
--- a/spec/usurper/functional/func_usurper_spec.rb
+++ b/spec/usurper/functional/func_usurper_spec.rb
@@ -12,7 +12,7 @@ feature 'User Browsing', js: true do
   scenario 'Find A-Z Databases', :read_only, :smoke_test do
     visit '/'
     within('.uNavigation') do
-      find_by_id('research').trigger('click')
+      find_by_id('research').click
       click_on('Databases A-Z')
     end
     az_databases = Usurper::Pages::AZDatabases.new
@@ -22,7 +22,7 @@ feature 'User Browsing', js: true do
   scenario 'Find A-Z Subjects', :read_only, :smoke_test do
     visit '/'
     within('.uNavigation') do
-      find_by_id('research').trigger('click')
+      find_by_id('research').click
       click_on('Subjects A-Z')
     end
     az_subjects = Usurper::Pages::AZSubjects.new
@@ -32,7 +32,7 @@ feature 'User Browsing', js: true do
   scenario 'Research Guides', :read_only, :smoke_test do
     visit '/'
     within('.uNavigation') do
-      find_by_id('research').trigger('click')
+      find_by_id('research').click
       click_on('Library Guides')
     end
     research_guides = Usurper::Pages::ResearchGuidesPage.new
@@ -42,7 +42,7 @@ feature 'User Browsing', js: true do
   scenario 'Reserve a Room underneath Services Tab', :read_only, :smoke_test do
     visit '/'
     within('.uNavigation') do
-      find_by_id('services').trigger('click')
+      find_by_id('services').click
       click_on('Reserve a Meeting or Event Space')
     end
     room_reservation_services_tab = Usurper::Pages::RoomReservationServicesTabPage.new
@@ -52,7 +52,7 @@ feature 'User Browsing', js: true do
   scenario 'Reserve a Room Button', :read_only, :smoke_test do
     visit '/'
     within('.services.hservices') do
-      find_link(title: 'Reserve a Room', href: "http://nd.libcal.com/#s-lc-box-2749-container-tab1").trigger('click')
+      find_link(title: 'Reserve a Room', href: "http://nd.libcal.com/#s-lc-box-2749-container-tab1").click
     end
     room_reservation = Usurper::Pages::RoomReservationPage.new
     expect(room_reservation).to be_on_page
@@ -61,7 +61,7 @@ feature 'User Browsing', js: true do
   scenario 'Technology Lending Button', :read_only, :smoke_test do
     visit '/'
     within('.services.hservices') do
-      find_link(title: 'Technology Lending').trigger('click')
+      find_link(title: 'Technology Lending').click
     end
     technology_lending = Usurper::Pages::TechnologyLendingPage.new
     expect(technology_lending).to be_on_page
@@ -122,10 +122,10 @@ feature 'User Browsing', js: true do
   scenario 'Go to Workshops page', :read_only do
     visit '/'
     find('#services').click
-    find_link('Workshops', href: '/workshops').trigger('click')
+    find_link('Workshops', href: '/workshops').click
     workshop = Usurper::Pages::WorkshopPage.new
     expect(workshop).to be_on_page
-    find_link('Library Workshop Registration Portal').trigger('click')
+    find_link('Library Workshop Registration Portal').click
     calendar = Usurper::Pages::CalendarPage.new
     expect(calendar).to be_on_page
   end
@@ -140,7 +140,7 @@ feature 'User Browsing', js: true do
   scenario 'Search using OneSearch from HomePage', :read_only do
     visit '/'
 <<<<<<< HEAD
-    find_button('Search').trigger('click')
+    find_button('Search').click
     search = Usurper::Pages::SearchPage.new
     sleep(2)
     expect(search).to be_on_page
@@ -152,7 +152,7 @@ feature 'User Browsing', js: true do
     within('.uSearchOptionList') do
       find('p', text: 'ND Catalog').click
     end
-    find_button('Search').trigger('click')
+    find_button('Search').click
     search = Usurper::Pages::SearchPage.new
     sleep(2)
     expect(search).to be_on_page
@@ -164,7 +164,7 @@ feature 'User Browsing', js: true do
     within('.uSearchOptionList') do
       find('p', text: 'CurateND').click
     end
-    find_button('Search').trigger('click')
+    find_button('Search').click
     sleep(2)
     expect(current_url).to match(/^https:\/\/curate.nd.edu\/catalog./)
   end
@@ -175,7 +175,7 @@ feature 'User Browsing', js: true do
     within('.uSearchOptionList') do
       find('p', text: 'Library Website').click
     end
-    find_button('Search').trigger('click')
+    find_button('Search').click
     sleep(2)
     expect(current_url).to match(/^https:\/\/search.nd.edu\/search\/./)
   end
@@ -223,7 +223,7 @@ feature 'User Navigation', js: true do
   scenario 'Thesis Camps', :read_only, :smoke_test do
     visit '/'
     within('.uNavigation') do
-      find_by_id('services').trigger('click')
+      find_by_id('services').click
       click_on('Thesis and Dissertation Camps')
     end
     thesis_camp = Usurper::Pages::ThesisCampsCheck.new
@@ -233,7 +233,7 @@ feature 'User Navigation', js: true do
   scenario 'Library Page Navigation', :read_only, :smoke_test do
     visit '/'
     within('.uNavigation') do
-      find_by_id('libraries').trigger('click')
+      find_by_id('libraries').click
     end
     librarylist = nil
     within('.col-md-offset-2.col-md-3') do
@@ -255,10 +255,10 @@ feature 'User Navigation', js: true do
       within('.building') do
         find('.map')
       end
-      find_link('Home').trigger('click')
+      find_link('Home').click
       sleep(2)
       within('.uNavigation') do
-        find_by_id('libraries').trigger('click')
+        find_by_id('libraries').click
       end
     end
   end

--- a/spec/usurper/functional/func_usurper_spec.rb
+++ b/spec/usurper/functional/func_usurper_spec.rb
@@ -4,7 +4,6 @@ require 'usurper/usurper_spec_helper'
 
 feature 'User Browsing', js: true do
   scenario 'Load Homepage', :read_only, :smoke_test do
-    page.driver.browser.js_errors = false
     visit '/'
     home_page = Usurper::Pages::HomePage.new
     expect(home_page).to be_on_page
@@ -31,7 +30,6 @@ feature 'User Browsing', js: true do
   end
 
   scenario 'Research Guides', :read_only, :smoke_test do
-    page.driver.browser.js_errors = false
     visit '/'
     within('.uNavigation') do
       find_by_id('research').trigger('click')
@@ -42,11 +40,9 @@ feature 'User Browsing', js: true do
   end
 
   scenario 'Reserve a Room underneath Services Tab', :read_only, :smoke_test do
-    page.driver.browser.js_errors = false
     visit '/'
     within('.uNavigation') do
       find_by_id('services').trigger('click')
-      page.driver.browser.js_errors = false
       click_on('Reserve a Meeting or Event Space')
     end
     room_reservation_services_tab = Usurper::Pages::RoomReservationServicesTabPage.new
@@ -54,7 +50,6 @@ feature 'User Browsing', js: true do
   end
 
   scenario 'Reserve a Room Button', :read_only, :smoke_test do
-    page.driver.browser.js_errors = false
     visit '/'
     within('.services.hservices') do
       find_link(title: 'Reserve a Room', href: "http://nd.libcal.com/#s-lc-box-2749-container-tab1").trigger('click')
@@ -64,10 +59,8 @@ feature 'User Browsing', js: true do
   end
 
   scenario 'Technology Lending Button', :read_only, :smoke_test do
-    page.driver.browser.js_errors = false
     visit '/'
     within('.services.hservices') do
-      page.driver.browser.js_errors = false
       find_link(title: 'Technology Lending').trigger('click')
     end
     technology_lending = Usurper::Pages::TechnologyLendingPage.new
@@ -75,7 +68,6 @@ feature 'User Browsing', js: true do
   end
 
   scenario 'Go to Library Giving Page', :read_only, :smoke_test do
-    page.driver.browser.js_errors = false
     visit '/'
     within('.row.bottom-xs') do
       click_on('Library Giving')
@@ -85,7 +77,6 @@ feature 'User Browsing', js: true do
   end
 
   scenario 'Go to Library Jobs Page', :read_only, :smoke_test do
-    page.driver.browser.js_errors = false
     visit '/'
     within('.row.bottom-xs') do
       click_on('Jobs')
@@ -120,7 +111,6 @@ feature 'User Browsing', js: true do
   end
 
   scenario 'Chat with Librarian via button', :read_only do
-    page.driver.browser.js_errors = false
     visit '/'
     within('#chat.footer-chat') do
       find('.chat-button').click
@@ -130,7 +120,6 @@ feature 'User Browsing', js: true do
   end
 
   scenario 'Go to Workshops page', :read_only do
-    page.driver.browser.js_errors = false
     visit '/'
     find('#services').click
     find_link('Workshops', href: '/workshops').trigger('click')
@@ -142,7 +131,6 @@ feature 'User Browsing', js: true do
   end
 
   scenario 'Go to Hours Page', :read_only do
-    page.driver.browser.js_errors = false
     visit '/'
     find_link('Hours', href: '/hours').click
     hours = Usurper::Pages::HoursPage.new
@@ -150,9 +138,8 @@ feature 'User Browsing', js: true do
   end
 
   scenario 'Search using OneSearch from HomePage', :read_only do
-    page.driver.browser.js_errors = false
     visit '/'
-    page.driver.browser.js_errors = false # Suprressing JS errors from OneSearch site
+<<<<<<< HEAD
     find_button('Search').trigger('click')
     search = Usurper::Pages::SearchPage.new
     sleep(2)
@@ -160,13 +147,11 @@ feature 'User Browsing', js: true do
   end
 
   scenario 'Search using ND Catalog from HomePage', :read_only do
-    page.driver.browser.js_errors = false
     visit '/'
     find('.current-search').click
     within('.uSearchOptionList') do
       find('p', text: 'ND Catalog').click
     end
-    page.driver.browser.js_errors = false # Suprressing JS errors from OneSearch site
     find_button('Search').trigger('click')
     search = Usurper::Pages::SearchPage.new
     sleep(2)
@@ -174,7 +159,6 @@ feature 'User Browsing', js: true do
   end
 
   scenario 'Search using CurateND from HomePage', :read_only do
-    page.driver.browser.js_errors = false
     visit '/'
     find('.current-search').click
     within('.uSearchOptionList') do
@@ -186,7 +170,6 @@ feature 'User Browsing', js: true do
   end
 
   scenario 'Search using Library Website from HomePage', :read_only do
-    page.driver.browser.js_errors = false
     visit '/'
     find('.current-search').click
     within('.uSearchOptionList') do
@@ -202,7 +185,6 @@ feature 'Logged In User Browsing', js: true do
   let(:login) { LoginPage.new(current_logger) }
 
   scenario 'Log In', :read_only, :validates_login do
-    page.driver.browser.js_errors = false
     visit '/'
     click_on('Login')
     login.complete_login
@@ -211,7 +193,6 @@ feature 'Logged In User Browsing', js: true do
   end
 
   scenario 'View Checked Out/Pending Items', :read_only do
-    page.driver.browser.js_errors = false
     visit '/'
     click_on('Login')
     login.complete_login
@@ -222,7 +203,6 @@ feature 'Logged In User Browsing', js: true do
 
   scenario 'View Courses/Instructs', :read_only do
     # Does not run properly do to issues with
-    page.driver.browser.js_errors = false
     visit '/'
     click_on('Login')
     login.complete_login
@@ -235,14 +215,12 @@ end
 
 feature 'User Navigation', js: true do
   scenario 'All Feature in Tab', :read_only, :smoke_test do
-    page.driver.browser.js_errors = false
     visit '/'
     header_all_checks = Usurper::Pages::HeaderAllChecks.new
     expect(header_all_checks).to be_on_page
   end
 
   scenario 'Thesis Camps', :read_only, :smoke_test do
-    page.driver.browser.js_errors = false
     visit '/'
     within('.uNavigation') do
       find_by_id('services').trigger('click')
@@ -253,7 +231,6 @@ feature 'User Navigation', js: true do
   end
 
   scenario 'Library Page Navigation', :read_only, :smoke_test do
-    page.driver.browser.js_errors = false
     visit '/'
     within('.uNavigation') do
       find_by_id('libraries').trigger('click')

--- a/spec/usurper/functional/func_usurper_spec.rb
+++ b/spec/usurper/functional/func_usurper_spec.rb
@@ -139,7 +139,6 @@ feature 'User Browsing', js: true do
 
   scenario 'Search using OneSearch from HomePage', :read_only do
     visit '/'
-<<<<<<< HEAD
     find_button('Search').click
     search = Usurper::Pages::SearchPage.new
     sleep(2)

--- a/spec/usurper/pages/base_page.rb
+++ b/spec/usurper/pages/base_page.rb
@@ -11,14 +11,9 @@ module Usurper
       end
 
       def on_page?
-        status_response_ok? &&
-          valid_header? &&
+        valid_header? &&
           valid_footer? &&
           valid_version?
-      end
-
-      def status_response_ok?
-        status_code == 200 || status_code == 304
       end
 
       def valid_header?

--- a/spec/usurper/pages/base_page.rb
+++ b/spec/usurper/pages/base_page.rb
@@ -22,16 +22,16 @@ module Usurper
         end
         within('.uNavigation') do
           find_link('Home', href: '/').visible?
-          find_by_id('research').trigger('click')
+          find_by_id('research').click
           menu_drawer_has_content?
-          find_by_id('services').trigger('click')
+          find_by_id('services').click
           menu_drawer_has_content?
-          find_by_id('libraries').trigger('click')
+          find_by_id('libraries').click
           menu_drawer_has_content?
-          find_by_id('about').trigger('click')
+          find_by_id('about').click
           menu_drawer_has_content?
           # need to close 'About' tab or issues randomly pop up
-          find('a', id: 'about').trigger('click')
+          find('a', id: 'about').click
           if @loggedin
             find('.m', text: 'MY ACCOUNT')
           else

--- a/spec/usurper/pages/header_tab_all_checks.rb
+++ b/spec/usurper/pages/header_tab_all_checks.rb
@@ -14,17 +14,17 @@ module Usurper
 
       def correct_content?
         within('.uNavigation') do
-          find_by_id('research').trigger('click')
+          find_by_id('research').click
         end
         within('.menu-drawer.visible') do
-          find('.viewAll.viewMore').trigger('click')
+          find('.viewAll.viewMore').click
           current_url == File.join(Capybara.app_host, 'research')
         end
         within('.uNavigation') do
-          find_by_id('services').trigger('click')
+          find_by_id('services').click
         end
         within('.menu-drawer.visible') do
-          find('.viewAll.viewMore').trigger('click')
+          find('.viewAll.viewMore').click
           current_url == File.join(Capybara.app_host, 'services')
         end
       end

--- a/spec/usurper/pages/home_page.rb
+++ b/spec/usurper/pages/home_page.rb
@@ -55,7 +55,7 @@ module Usurper
           find('h2', text: 'News') &&
             all('.news-card', between: 1..3)
           find('h2', text: 'Events') &&
-            all('.event-card', between: 1..3)
+            all('.event-card', between: 1..10)
         end
       end
 

--- a/spec/usurper/pages/lib_calendar_page.rb
+++ b/spec/usurper/pages/lib_calendar_page.rb
@@ -14,12 +14,7 @@ module Usurper
 
       def on_page?
         correct_content? &&
-          correct_url? &&
-          status_response_ok?
-      end
-
-      def status_response_ok?
-        status_code == 200
+          correct_url?
       end
 
       def correct_content?

--- a/spec/usurper/pages/lib_calendar_page.rb
+++ b/spec/usurper/pages/lib_calendar_page.rb
@@ -9,7 +9,7 @@ module Usurper
 
       def initialize
         last_opened_window = page.driver.browser.window_handles.last
-        page.driver.browser.switch_to_window(last_opened_window)
+        page.driver.browser.switch_to.window(last_opened_window)
       end
 
       def on_page?

--- a/spec/usurper/pages/library_giving_page.rb
+++ b/spec/usurper/pages/library_giving_page.rb
@@ -18,7 +18,7 @@ module Usurper
 
       def on_valid_url?
         last_opened_window = page.driver.browser.window_handles.last
-        page.driver.browser.switch_to_window(last_opened_window)
+        page.driver.browser.switch_to.window(last_opened_window)
         current_url == 'http://librarygiving.nd.edu/'
       end
     end

--- a/spec/usurper/pages/library_page_navigation.rb
+++ b/spec/usurper/pages/library_page_navigation.rb
@@ -14,7 +14,7 @@ module Usurper
 
       def on_valid_url?
         last_opened_window = page.driver.browser.window_handles.last
-        page.driver.browser.switch_to_window(last_opened_window)
+        page.driver.browser.switch_to.window(last_opened_window)
         current_url.include?('https://www.google.com/maps/place/')
       end
     end

--- a/spec/usurper/pages/reseach_guides_page.rb
+++ b/spec/usurper/pages/reseach_guides_page.rb
@@ -9,7 +9,7 @@ module Usurper
       def initialize
         VerifyNetworkTraffic.exclude_uri_from_network_traffic_validation.push('/svn/loader/run_prettify.js', '/libapps/sites/3767/include/img/jesus.gif')
         last_opened_window = page.driver.browser.window_handles.last
-        page.driver.browser.switch_to_window(last_opened_window)
+        page.driver.browser.switch_to.window(last_opened_window)
       end
 
       def on_page?

--- a/spec/usurper/pages/reserve_a_room_page.rb
+++ b/spec/usurper/pages/reserve_a_room_page.rb
@@ -15,7 +15,7 @@ module Usurper
         # Link to the libcal reserve library spaces page
         libcal_room_reservation = 'http://nd.libcal.com/#s-lc-box-2749-container-tab1'
         last_opened_window = page.driver.browser.window_handles.last
-        page.driver.browser.switch_to_window(last_opened_window)
+        page.driver.browser.switch_to.window(last_opened_window)
         current_url == libcal_room_reservation
       end
     end

--- a/spec/usurper/pages/search_page.rb
+++ b/spec/usurper/pages/search_page.rb
@@ -15,8 +15,7 @@ module Usurper
       def on_page?
         sleep(2)
         valid_url? &&
-          correct_content? &&
-          valid_status?
+          correct_content?
       end
 
       def valid_url?
@@ -36,10 +35,6 @@ module Usurper
           else
             page.has_selector?('.EXLSearchFieldMaximized.long.EXLSearchFieldMaximized.srch-box')
           end
-      end
-
-      def valid_status?
-        status_code == 200
       end
     end
   end


### PR DESCRIPTION
## Removes 'status_code' asserts from Usurper specs

0878777023df151af63158ff33383636d9c8976d

I am leveraging Selenium webdriver with Chrome headless. 'status_code'
method is not supported with Selenium.

## Removes javascript error suppression

2bd2f823b5116d15c396b3975304ef3956408084

This method is not supported by Selenium
```error
undefined method `js_errors=' for #<Selenium::WebDriver::Remote::Driver
```

## Event cards can be more than 3

224d3aed8dc2d143156d4e5a51b998ab945b7134


## Replaces trigger('click') by `click` in usurper

748de02ae820f0d03dfdfe8b59a4808be5d39e37

`Capybara::Driver::Node#trigger` method is not supported with Selenium
driver. Spec raises an error:
```error
Capybara::NotSupportedByDriverError Exception: Capybara::Driver::Node#trigger
```

## Rubocop fixes

da28dafe5efb5e960b85fcde0d60082987c83c53


## Moves from 'switch_to_window' to 'switch_to'
7c6a97c0583ad8261d1942d0c478f112a947a1a3

`switch_to_window` is not supported by Selenium. The correct way
to do the same thing is `switch_to.window`