### PR TITLE
Changing asserts to Primo NUI and simplifying search specs

### DIFF
--- a/spec/usurper/functional/func_usurper_spec.rb
+++ b/spec/usurper/functional/func_usurper_spec.rb
@@ -141,7 +141,6 @@ feature 'User Browsing', js: true do
     visit '/'
     find_button('Search').click
     search = Usurper::Pages::SearchPage.new
-    sleep(2)
     expect(search).to be_on_page
   end
 
@@ -153,7 +152,6 @@ feature 'User Browsing', js: true do
     end
     find_button('Search').click
     search = Usurper::Pages::SearchPage.new
-    sleep(2)
     expect(search).to be_on_page
   end
 


### PR DESCRIPTION
* Generalizes url assertion with a regex
* Removes sleep statements and leverages sleep injection in
`page.has_selector?` from Capybara-maleficent gem
* Changes content assertions to look for Primo NUI