### PR TITLE
Usurper spec changes for LW release r20180706

### DIFF
--- a/spec/usurper/functional/func_usurper_spec.rb
+++ b/spec/usurper/functional/func_usurper_spec.rb
@@ -173,8 +173,8 @@ feature 'User Browsing', js: true do
       find('p', text: 'Library Website').click
     end
     find_button('Search').click
-    sleep(2)
-    expect(current_url).to match(/^https:\/\/search.nd.edu\/search\/./)
+    expect(page).to have_content('Website Search')
+    expect(current_url).to start_with(File.join(Capybara.app_host, '/search?q='))
   end
 end
 

--- a/spec/usurper/pages/search_page.rb
+++ b/spec/usurper/pages/search_page.rb
@@ -8,7 +8,7 @@ module Usurper
 
       def initialize
         VerifyNetworkTraffic.exclude_uri_from_network_traffic_validation.push('/primo-explore/config_NDUA.js', '/PDSMExlibris.css')
-        @onesearch_url_regex = /http:\/\/onesearch.library.nd.edu\/primo-explore.*/
+        @onesearch_url_regex = /http.*:\/\/onesearch.*.library.nd.edu\/primo-explore.*/
       end
 
       def on_page?

--- a/spec/usurper/pages/search_page.rb
+++ b/spec/usurper/pages/search_page.rb
@@ -8,7 +8,7 @@ module Usurper
 
       def initialize
         VerifyNetworkTraffic.exclude_uri_from_network_traffic_validation.push('/primo-explore/config_NDUA.js', '/PDSMExlibris.css')
-        @onesearch_url_regex = /http.*:\/\/onesearch.*.library.nd.edu\/primo-explore.*/
+        @onesearch_url_regex = /http.*:\/\/onesearch.*\.library\.nd\.edu\/primo-explore.*/
       end
 
       def on_page?


### PR DESCRIPTION
## Updates regex to for http/https and nonprod

8db218ea628e978e42d5fe6e02e4625be2235d8f

* Accommodates http and https
* Accommodates prod and non-prod
non-prod: https://onesearchpprd.library.nd.edu/
prod: http://onesearch.library.nd.edu/

## Escapes periods in hostname

23b4364bb991abd86ba73e34f7f24ebe15f2d607

Escapes . (period) in hostname, otherwise in Ruby Regexp a . is
treated as any character

## Adjusts for LW-414, search using 'library website'

6c4fd1702b3f7fd8ffa6f35f2286944a028c3669

* Prefers `has_content?` over sleep statements to leverage built-in
wait logic from capybara-maleficent gem
* Adjusts URL assertion using start with so that the assertion stays
valid even with different search parameters