### PR TITLE
Test existing DOI link redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Here are some we should use consistently across all tests:
 * :smoke_test - checks application and dependent system availability
 * :read_only - will not make add/update to the underlying data (aside from login counts)
 * :nonprod_only - should not be run in production
+* :prod_only - should not be run in non-production
 * :regression_test - covers an important regression test
 * :authentication_required - requires logging into CAS
 

--- a/spec/spec_support/spec_filter_manager.rb
+++ b/spec/spec_support/spec_filter_manager.rb
@@ -21,6 +21,9 @@ module SpecFilterManager
       end
     elsif environment_under_test_is_nonprod?
       puts "'ENVIRONMENT' categorized as 'non-production', no filters, running all specs"
+      RSpec.configure do |c|
+        c.filter_run_excluding :prod_only
+      end
     else
       # I don't want to assume anything based on regex patterns when 'ENVIRONMENT' is a URL
       # Especially in cases such as that of library website when the URLs are cloudfront URLs


### PR DESCRIPTION
## Adds rspec tag to support prod-only filtering

c744911e0426ac65b6aaf23357fd7ca6d2058e1c


## DLTP-1445: Test existing doi link redirection

88f74b7df648c6b190273d75911eebabfaff5f52

- Created a feature block for all things DOI
- Moved the new DOI test to this block
- Created a test that ensures the doi link on objects will properly redirect back to the object via the doi handler. Tagged for production only since links in pprd will redirect to prod objects, causing a false positive
