### PR TITLE
Switches assertions for EZid to datacite migration

### DIFF
--- a/spec/curate/pages/edit_work_page.rb
+++ b/spec/curate/pages/edit_work_page.rb
@@ -22,7 +22,7 @@ module Curate
       def has_editable_doi?
         within('#doi') do
           has_content?('Digital Object Identifier')
-          find_link(href: /http.*:\/\/.*doi.org\/doi:.*\/.*/)
+          find_link(href: /http.*:\/\/.*datacite.org\/doi:.*\/.*/)
         end
         # Checks if an editable text box exists
         find('#image_doi')

--- a/spec/curate/pages/show_article.rb
+++ b/spec/curate/pages/show_article.rb
@@ -65,7 +65,7 @@ module Curate
       def has_doi?
         has_content?('Digital Object Identifier')
         on_valid_url?
-        find_link(href: /http.*:\/\/.*doi.org\/doi:.*\/.*/)
+        find_link(href: /http.*:\/\/.*datacite.org\/doi:.*\/.*/)
       end
     end
   end


### PR DESCRIPTION
With curate release tag v2018.21, doi links will redirect to
https://handle.test.datacite.org/* in non-prod accounts.