### PR TITLE
Library website r20180720 changes

### DIFF
--- a/spec/spec_support/cas_login.rb
+++ b/spec/spec_support/cas_login.rb
@@ -59,7 +59,7 @@ class LoginPage
     find('.form-signin [name=submit]').click
     page.has_content?('Welcome to the new Notre Dame login process')
     page.driver.browser.switch_to.frame('duo_iframe')
-    find('button.positive.auth-button').click
+    find('#passcode').click
     page.has_selector?("input[name=passcode]")
     fill_in('passcode', with: passcode)
     current_logger.info(context: "Logging in user: #{user_name}")

--- a/spec/usurper/pages/library_giving_page.rb
+++ b/spec/usurper/pages/library_giving_page.rb
@@ -17,9 +17,10 @@ module Usurper
       end
 
       def on_valid_url?
+        url_regex = /http.*:\/\/librarygiving.nd.edu.*/
         last_opened_window = page.driver.browser.window_handles.last
         page.driver.browser.switch_to.window(last_opened_window)
-        current_url == 'http://librarygiving.nd.edu/'
+        (current_url =~ url_regex).nil? ? false : true
       end
     end
   end


### PR DESCRIPTION
## Changes URL validation to use regex for http(s)

1778a4f4100e2681ce2ca32007ee96adaabb998e


## Using 'id' of the button to avoid ambiguous matches

f2145ddf3a995b523cac95f036be59edcaa82df8