### PR TITLE
Cuts over sipity specs to use chrome headless

### DIFF
--- a/spec/sipity/pages/dashboard.rb
+++ b/spec/sipity/pages/dashboard.rb
@@ -8,16 +8,11 @@ module Sipity
 
       def on_page?
         on_valid_url? &&
-          status_response_ok? &&
           valid_page_content?
       end
 
       def on_valid_url?
         current_url == Capybara.app_host + 'dashboard'
-      end
-
-      def status_response_ok?
-        status_code.to_s.match(/^20[0,1,6]$/)
       end
 
       def valid_page_content?

--- a/spec/sipity/pages/etd_submission_page.rb
+++ b/spec/sipity/pages/etd_submission_page.rb
@@ -8,16 +8,11 @@ module Sipity
 
       def on_page?
         on_valid_url? &&
-          status_response_ok? &&
           valid_page_content?
       end
 
       def on_valid_url?
         current_url == Capybara.app_host + 'areas/etd/start/do/start_a_submission'
-      end
-
-      def status_response_ok?
-        status_code.to_s.match(/^20[0,1,6]$/)
       end
 
       def valid_page_content?

--- a/spec/sipity/pages/etd_welcome.rb
+++ b/spec/sipity/pages/etd_welcome.rb
@@ -8,16 +8,11 @@ module Sipity
 
       def on_page?
         on_valid_url? &&
-          status_response_ok? &&
           valid_page_content?
       end
 
       def on_valid_url?
         current_url == Capybara.app_host + 'account'
-      end
-
-      def status_response_ok?
-        status_code.to_s.match(/^20[0,1,6]$/)
       end
 
       def valid_page_content?

--- a/spec/sipity/pages/home_page.rb
+++ b/spec/sipity/pages/home_page.rb
@@ -8,16 +8,11 @@ module Sipity
 
       def on_page?
         on_valid_url? &&
-          status_response_ok? &&
           valid_page_content?
       end
 
       def on_valid_url?
         current_url == File.join(Capybara.app_host, 'areas/etd')
-      end
-
-      def status_response_ok?
-        status_code.to_s.match(/^20[0,1,6]$/)
       end
 
       def valid_page_content?

--- a/spec/sipity/pages/new_deposit.rb
+++ b/spec/sipity/pages/new_deposit.rb
@@ -8,16 +8,11 @@ module Sipity
 
       def on_page?
         on_valid_url? &&
-          status_response_ok? &&
           valid_page_content?
       end
 
       def on_valid_url?
         current_url == Capybara.app_host + 'areas/etd/start'
-      end
-
-      def status_response_ok?
-        status_code.to_s.match(/^20[0,1,6]$/)
       end
 
       def valid_page_content?

--- a/spec/sipity/pages/signed_in_page.rb
+++ b/spec/sipity/pages/signed_in_page.rb
@@ -8,16 +8,11 @@ module Sipity
 
       def on_page?
         on_valid_url? &&
-          status_response_ok? &&
           valid_page_content?
       end
 
       def on_valid_url?
         current_url == Capybara.app_host + 'areas/etd'
-      end
-
-      def status_response_ok?
-        status_code.to_s.match(/^20[0,1,6]$/)
       end
 
       def valid_page_content?

--- a/spec/sipity/pages/submitted_etd.rb
+++ b/spec/sipity/pages/submitted_etd.rb
@@ -8,16 +8,11 @@ module Sipity
 
       def on_page?
         on_valid_url? &&
-          status_response_ok? &&
           valid_page_content?
       end
 
       def on_valid_url?
         current_url == 'https://curate.nd.edu/catalog?f_inclusive%5Bhuman_readable_type_sim%5D%5B%5D=Doctoral+Dissertation&f_inclusive%5Bhuman_readable_type_sim%5D%5B%5D=Master%27s+Thesis'
-      end
-
-      def status_response_ok?
-        status_code.to_s.match(/^20[0,1,6]$/)
       end
 
       def valid_page_content?

--- a/spec/spec_support/cas_login.rb
+++ b/spec/spec_support/cas_login.rb
@@ -70,16 +70,11 @@ class LoginPage
 
   def on_page?
     on_valid_url? &&
-      status_response_ok? &&
       valid_page_content?
   end
 
   def on_valid_url?
     current_url.start_with?('https://login.nd.edu/cas/login')
-  end
-
-  def status_response_ok?
-    status_code.to_s.match(/^20[0,1,6]$/)
   end
 
   def valid_page_content?


### PR DESCRIPTION
`status_code` method is not supported with selenium web driver. These changes remove status code assertions from the sipity pages and the shared LoginPage class