### PR TITLE
Refactors sipity specs

### DIFF
--- a/spec/sipity/functional/func_sipity_spec.rb
+++ b/spec/sipity/functional/func_sipity_spec.rb
@@ -8,7 +8,6 @@ def visit_home
 end
 
 def sign_in
-  visit_home
   within('div.collapse.navbar-collapse') do
     find_link('Sign in').click
   end
@@ -16,16 +15,16 @@ def sign_in
   casLogin.complete_login
 end
 
-def returning_user_sign_in
-  sign_in
-  signed_in_page = Sipity::Pages::SignedInPage.new
-  expect(signed_in_page).to be_on_page
+def sign_out
+  find_link("Sign out").click
+  expect(casLogin).to be_on_page
 end
 
-feature 'First Time User', js: true do
+feature 'First time user', js: true do
   let(:casLogin) { LoginPage.new(current_logger, terms_of_service_accepted: false) }
 
-  scenario 'FIRST TIME User Sign In', :validates_login, :read_only, js: true do
+  scenario 'Sign In', :validates_login, :read_only, js: true do
+    visit_home
     sign_in
     welcome_page = Sipity::Pages::ETDWelcomePage.new
     expect(welcome_page).to be_on_page
@@ -35,51 +34,36 @@ feature 'First Time User', js: true do
   end
 end
 
-feature 'User Browsing', js: true do
+feature 'Returning User', js: true do
   let(:casLogin) { LoginPage.new(current_logger, terms_of_service_accepted: true) }
 
-  scenario 'Visit Homepage', :smoke_test, :read_only do
+  scenario 'Browsing dashboard', :smoke_test, :read_only do
     visit_home
-  end
-
-  scenario 'RETURN User Sign In', :validates_login, :read_only, js: true do
-    returning_user_sign_in
-  end
-
-  scenario 'View Dashboard', :read_only, js: true do
-    returning_user_sign_in
+    sign_in
+    signed_in_page = Sipity::Pages::SignedInPage.new
+    expect(signed_in_page).to be_on_page
+    # Tests 'Dashboard'
     find_link("Dashboard").click
     dashboard = Sipity::Pages::Dashboard.new
     expect(dashboard).to be_on_page
-  end
-
-  scenario 'Start an ETD Submission', :read_only, js: true do
-    returning_user_sign_in
-    find_link("Start an ETD Submission").click
-    submission_page = Sipity::Pages::ETDSubmissionPage.new
-    expect(submission_page).to be_on_page
-  end
-
-  scenario 'View Submitted ETDs', :read_only, js: true do
-    returning_user_sign_in
-    find_link("View Submitted ETDs").click
-    submission_page = Sipity::Pages::SubmittedETDPage.new
-    expect(submission_page).to be_on_page
-  end
-
-  scenario 'View New Deposit Page', :read_only, js: true do
-    returning_user_sign_in
-    find_link("Dashboard").click
-    dashboard = Sipity::Pages::Dashboard.new
-    expect(dashboard).to be_on_page
+    # Tests 'New Deposit page'
     find_link('New Deposit').click
     new_deposit_page = Sipity::Pages::NewDepositPage.new
     expect(new_deposit_page).to be_on_page
+    sign_out
   end
 
-  scenario 'Sign Out', :read_only, js: true do
-    returning_user_sign_in
-    find_link("Sign out").click
-    expect(casLogin).to be_on_page
+  scenario 'Browse ETD buttons', :read_only, js: true do
+    visit_home
+    sign_in
+    find_link("Start an ETD Submission").click
+    submission_page = Sipity::Pages::ETDSubmissionPage.new
+    expect(submission_page).to be_on_page
+    page.go_back
+    # Tests 'View Submitted ETDs'
+    find_link("View Submitted ETDs").click
+    submission_page = Sipity::Pages::SubmittedETDPage.new
+    expect(submission_page).to be_on_page
+    sign_out
   end
 end

--- a/spec/sipity/functional/func_sipity_spec.rb
+++ b/spec/sipity/functional/func_sipity_spec.rb
@@ -1,6 +1,26 @@
 # frozen_string_literal: true
 
 require 'sipity/sipity_spec_helper'
+def visit_home
+  visit '/'
+  home_page = Sipity::Pages::HomePage.new
+  expect(home_page).to be_on_page
+end
+
+def sign_in
+  visit_home
+  within('div.collapse.navbar-collapse') do
+    find_link('Sign in').click
+  end
+  expect(casLogin).to be_on_page
+  casLogin.complete_login
+end
+
+def returning_user_sign_in
+  sign_in
+  signed_in_page = Sipity::Pages::SignedInPage.new
+  expect(signed_in_page).to be_on_page
+end
 
 feature 'First Time User', js: true do
   let(:casLogin) { LoginPage.new(current_logger, terms_of_service_accepted: false) }
@@ -62,25 +82,4 @@ feature 'User Browsing', js: true do
     find_link("Sign out").click
     expect(casLogin).to be_on_page
   end
-end
-
-def visit_home
-  visit '/'
-  home_page = Sipity::Pages::HomePage.new
-  expect(home_page).to be_on_page
-end
-
-def sign_in
-  visit_home
-  within('div.collapse.navbar-collapse') do
-    find_link('Sign in').click
-  end
-  expect(casLogin).to be_on_page
-  casLogin.complete_login
-end
-
-def returning_user_sign_in
-  sign_in
-  signed_in_page = Sipity::Pages::SignedInPage.new
-  expect(signed_in_page).to be_on_page
 end

--- a/spec/sipity/functional/func_sipity_spec.rb
+++ b/spec/sipity/functional/func_sipity_spec.rb
@@ -15,7 +15,7 @@ def sign_in
   casLogin.complete_login
 end
 
-def sign_out
+def sign_out_from_sipity
   find_link("Sign out").click
   expect(casLogin).to be_on_page
 end
@@ -50,7 +50,7 @@ feature 'Returning User', js: true do
     find_link('New Deposit').click
     new_deposit_page = Sipity::Pages::NewDepositPage.new
     expect(new_deposit_page).to be_on_page
-    sign_out
+    sign_out_from_sipity
   end
 
   scenario 'Browse ETD buttons', :read_only, js: true do
@@ -64,6 +64,5 @@ feature 'Returning User', js: true do
     find_link("View Submitted ETDs").click
     submission_page = Sipity::Pages::SubmittedETDPage.new
     expect(submission_page).to be_on_page
-    sign_out
   end
 end

--- a/spec/sipity/pages/dashboard.rb
+++ b/spec/sipity/pages/dashboard.rb
@@ -12,7 +12,7 @@ module Sipity
       end
 
       def on_valid_url?
-        current_url == Capybara.app_host + 'dashboard'
+        current_url == File.join(Capybara.app_host, 'dashboard')
       end
 
       def valid_page_content?

--- a/spec/sipity/pages/dashboard.rb
+++ b/spec/sipity/pages/dashboard.rb
@@ -7,8 +7,8 @@ module Sipity
       include CapybaraErrorIntel::DSL
 
       def on_page?
-        on_valid_url? &&
-          valid_page_content?
+        valid_page_content? &&
+          on_valid_url?
       end
 
       def on_valid_url?
@@ -16,15 +16,15 @@ module Sipity
       end
 
       def valid_page_content?
-        find("select[name='processing_state']")
-        find("input[value='Filter']")
-        find_link('New Deposit')
         table = find("table.table")
         table.has_content?("Title")
         table.has_content?("Creator(s)")
         table.has_content?("Type")
         table.has_content?("Processing State")
         table.has_content?("Date Created")
+        find("select[name='processing_state']")
+        find("input[value='Filter']")
+        find_link('New Deposit')
       end
     end
   end

--- a/spec/sipity/pages/etd_submission_page.rb
+++ b/spec/sipity/pages/etd_submission_page.rb
@@ -12,7 +12,7 @@ module Sipity
       end
 
       def on_valid_url?
-        current_url == Capybara.app_host + 'areas/etd/start/do/start_a_submission'
+        current_url == File.join(Capybara.app_host, 'areas/etd/start/do/start_a_submission')
       end
 
       def valid_page_content?

--- a/spec/sipity/pages/etd_submission_page.rb
+++ b/spec/sipity/pages/etd_submission_page.rb
@@ -7,8 +7,8 @@ module Sipity
       include CapybaraErrorIntel::DSL
 
       def on_page?
-        on_valid_url? &&
-          valid_page_content?
+        valid_page_content? &&
+          on_valid_url?
       end
 
       def on_valid_url?

--- a/spec/sipity/pages/etd_welcome.rb
+++ b/spec/sipity/pages/etd_welcome.rb
@@ -7,8 +7,8 @@ module Sipity
       include CapybaraErrorIntel::DSL
 
       def on_page?
-        on_valid_url? &&
-          valid_page_content?
+        valid_page_content? &&
+          on_valid_url?
       end
 
       def on_valid_url?

--- a/spec/sipity/pages/etd_welcome.rb
+++ b/spec/sipity/pages/etd_welcome.rb
@@ -12,7 +12,7 @@ module Sipity
       end
 
       def on_valid_url?
-        current_url == Capybara.app_host + 'account'
+        current_url == File.join(Capybara.app_host, 'account')
       end
 
       def valid_page_content?

--- a/spec/sipity/pages/home_page.rb
+++ b/spec/sipity/pages/home_page.rb
@@ -7,8 +7,8 @@ module Sipity
       include CapybaraErrorIntel::DSL
 
       def on_page?
-        on_valid_url? &&
-          valid_page_content?
+        valid_page_content? &&
+          on_valid_url?
       end
 
       def on_valid_url?

--- a/spec/sipity/pages/new_deposit.rb
+++ b/spec/sipity/pages/new_deposit.rb
@@ -7,8 +7,8 @@ module Sipity
       include CapybaraErrorIntel::DSL
 
       def on_page?
-        on_valid_url? &&
-          valid_page_content?
+        valid_page_content? &&
+          on_valid_url?
       end
 
       def on_valid_url?

--- a/spec/sipity/pages/new_deposit.rb
+++ b/spec/sipity/pages/new_deposit.rb
@@ -12,7 +12,7 @@ module Sipity
       end
 
       def on_valid_url?
-        current_url == Capybara.app_host + 'areas/etd/start'
+        current_url == File.join(Capybara.app_host, 'areas/etd/start')
       end
 
       def valid_page_content?

--- a/spec/sipity/pages/signed_in_page.rb
+++ b/spec/sipity/pages/signed_in_page.rb
@@ -7,8 +7,8 @@ module Sipity
       include CapybaraErrorIntel::DSL
 
       def on_page?
-        on_valid_url? &&
-          valid_page_content?
+        valid_page_content? &&
+          on_valid_url?
       end
 
       def on_valid_url?

--- a/spec/sipity/pages/signed_in_page.rb
+++ b/spec/sipity/pages/signed_in_page.rb
@@ -12,7 +12,7 @@ module Sipity
       end
 
       def on_valid_url?
-        current_url == Capybara.app_host + 'areas/etd'
+        current_url == File.join(Capybara.app_host, 'areas/etd')
       end
 
       def valid_page_content?

--- a/spec/sipity/pages/submitted_etd.rb
+++ b/spec/sipity/pages/submitted_etd.rb
@@ -16,12 +16,15 @@ module Sipity
       end
 
       def valid_page_content?
-        find('.btn.btn-primary.login').click
-        find("div.btn-group.my-actions").click
-        find("div.btn-group.my-actions.open")
+        # Sipity site behavior is such that user has to click login button
+        # again to logged in after getting redirected to curate
+        within('header.catalog.page-banner') do
+          find('.login').click
+          find("div.btn-group.my-actions").click
+        end
         has_content?("My Works")
         has_content?("My Collections")
-        has_content?("My Groups")
+        has_content?("Group Administration")
         has_content?("My Profile")
         has_content?("Log Out")
       end


### PR DESCRIPTION
## Preferring File.join over `+` for pathnames

6502dc6f88de53873884775fa5867a3a1bacc0ce

Using File.join helps avoid issues with missing/extra pathname
separators

## Asserting valid_page_content? before on_valid_url?

118057411d830c96ccb579cbcf1bba726247e794

valid_page_content? method uses assertions that have built in
support for wait using Capybara::Maleficient gem.
This provides more breathing room for page to load and makes
specs non-fragile

## Moves definitions to the top of scenario

f0eb5b4208b1e51b00206714ba7781a2a3a1faec


## Simplifies methods and scenarios

fba2d0166f09ff7256a4555be317d719a1fc1a9a

* Removes circulatory method calls for `visit_home` and `sign_in`
from other methods. Instead calling them from scenarios to improve
readability of scenario
* Adds a method for `sign_out`
* Simplifies feature and scenarios for 'first time' and 'Returning'
users.
* collapses scenarios for 'Returning users' to reduce the number
of logins, improves speed of overall excecution

## Renames 'sign_out' method & removes its extra call

6cb9b96f396dd8936ba7a36ae38e74a1f1a0837a
* Renaming to 'sign_out_from_sipity' so its more specific and
easy to understand.
* Removing it from 'Browse ETD buttons' scenario because after clicking
'View Submitted ETDs' the browser is redirected to Curate, and these
specs need not cover curate functionility testing.

## Adds comments, scoping and change in assertions

0dd2b211fba0aaa48d05fccd5826839ab37dc0ba

* Adding a comment about 'Login' button functionality/bug after
user gets redirected from sipity to curate
* Adds a within block for better scoping
* Changes assertion for 'My groups' menu button based on curate
changes