### PR TITLE
Curate spec changes for DOI release and other changes going along with it

### DIFF
--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -170,11 +170,11 @@ feature 'Logged In User (Account details NOT updated)', js: true do
     click_on("My Collections")
     account_details_page = Curate::Pages::AccountDetailsPage.new
     expect(account_details_page).to be_on_page
-    # Validate 'My Profile' page works
+    # Validate 'My Account' page works
     logged_in_home_page.open_actions_drawer
-    click_on("My Profile")
-    my_profile_page = Curate::Pages::MyProfilePage.new
-    expect(my_profile_page).to be_on_page
+    click_on("My Account")
+    my_account_page = Curate::Pages::MyAccountPage.new
+    expect(my_account_page).to be_on_page
     # Validate 'New Article' page works
     logged_in_home_page.open_add_content_drawer
     click_on("New Article")
@@ -231,11 +231,11 @@ feature 'Logged In User (Account details updated) Browsing', js: true do
     click_on("My Collections")
     collections_page = Curate::Pages::MyCollectionsPage.new
     expect(collections_page).to be_on_page
-    # Validate 'My Profile' page works
+    # Validate 'My Account' page works
     logged_in_home_page.open_actions_drawer
-    click_on("My Profile")
-    profile_page = Curate::Pages::MyProfilePage.new
-    expect(profile_page).to be_on_page
+    click_on("My Account")
+    account_page = Curate::Pages::MyAccountPage.new
+    expect(account_page).to be_on_page
     # Validate 'New Article' page works
     logged_in_home_page.open_add_content_drawer
     click_on("New Article")
@@ -407,9 +407,9 @@ feature 'Logged in user changing ORCID settings (Account Details Not Updated):',
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.open_actions_drawer
-    click_on("My Profile")
-    my_profile_page = Curate::Pages::MyProfilePage.new
-    expect(my_profile_page).to be_on_page
+    click_on("My Account")
+    my_account_page = Curate::Pages::MyAccountPage.new
+    expect(my_account_page).to be_on_page
     find_link('Add a Section to my Profile').click
     find_link('ORCID Settings').click
     sleep(1)
@@ -432,7 +432,7 @@ feature 'Logged in user changing ORCID settings (Account Details Updated):', js:
     logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
     expect(logged_in_home_page).to be_on_page
     logged_in_home_page.open_actions_drawer
-    click_on("My Profile")
+    click_on("My Account")
     click_on("Update Personal Information")
     account_details_page = Curate::Pages::AccountDetailsPage.new
     expect(account_details_page).to be_on_page

--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -397,33 +397,8 @@ feature 'Embargo scenarios:', js: true do
   end
 end
 
-feature 'Logged in user changing ORCID settings (Account Details Not Updated):', js: true do
-  let(:login_page) { LoginPage.new(current_logger, account_details_updated: false) }
-
-  scenario "Go to ORCID.org Signin page", :validates_login, :read_only do
-    visit '/'
-    click_on('Log In')
-    login_page.complete_login
-    logged_in_home_page = Curate::Pages::LoggedInHomePage.new(login_page)
-    expect(logged_in_home_page).to be_on_page
-    logged_in_home_page.open_actions_drawer
-    click_on("My Account")
-    my_account_page = Curate::Pages::MyAccountPage.new
-    expect(my_account_page).to be_on_page
-    find_link('Add a Section to my Profile').click
-    find_link('ORCID Settings').click
-    sleep(1)
-    orcid_settings_page = Curate::Pages::OrcidSettingsPage.new
-    expect(orcid_settings_page).to be_on_page
-    find_link('Create or Connect your ORCID iD').click
-    sleep(1)
-    orcid_home_page = Curate::Pages::OrcidHomePage.new
-    expect(orcid_home_page).to be_on_page(login_page.account_details_updated)
-  end
-end
-
-feature 'Logged in user changing ORCID settings (Account Details Updated):', js: true do
-  let(:login_page) { LoginPage.new(current_logger, account_details_updated: true) }
+feature 'Logged in user changing ORCID settings (Any account):', js: true do
+  let(:login_page) { LoginPage.new(current_logger) }
 
   scenario "Go to ORCID.org registration page", :validates_login, :read_only do
     visit '/'
@@ -443,7 +418,7 @@ feature 'Logged in user changing ORCID settings (Account Details Updated):', js:
     find_link('Create or Connect your ORCID iD').click
     sleep(1)
     orcid_home_page = Curate::Pages::OrcidHomePage.new
-    expect(orcid_home_page).to be_on_page(login_page.account_details_updated)
+    expect(orcid_home_page).to be_on_page
   end
 end
 

--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -297,7 +297,7 @@ feature 'Embargo scenarios:', js: true do
     image_page.create_temp_image(access_rights: 'embargo', embargo_date: false)
     # Since there is no embargo date the url should not change
     expect(current_url).to include('concern/images/new')
-    fill_in(id: 'image_embargo_release_date', with: Date.today + 1)
+    fill_in(id: 'image_embargo_release_date', with: Date.today + 2)
     find('.btn.btn-primary.require-contributor-agreement').click
     expect(page).to have_css('.label.label-warning', text: "Under Embargo")
     expect(current_url).not_to include('concern/images/new')
@@ -326,7 +326,7 @@ feature 'Embargo scenarios:', js: true do
     # To test that the embargo date requirement works
     find('.btn.btn-primary.require-contributor-agreement').click
     expect(current_url).not_to include('confirm')
-    fill_in(id: 'image_embargo_release_date', with: Date.today + 1)
+    fill_in(id: 'image_embargo_release_date', with: Date.today + 2)
     find('.btn.btn-primary.require-contributor-agreement').click
     expect(page).to have_css('.span12', text: "You've changed this foo to be open_with_embargo_release_date") # Leveraging Capybara::Maleficent.with_sleep_injection
     within('.button_to') do
@@ -384,7 +384,7 @@ feature 'Embargo scenarios:', js: true do
     within('#set-access-controls') do
       choose(id: 'visibility_embargo')
     end
-    fill_in(id: 'image_embargo_release_date', with: Date.today + 1)
+    fill_in(id: 'image_embargo_release_date', with: Date.today + 2)
     find('.btn.btn-primary.require-contributor-agreement').click
     expect(page).to have_css('.span12', text: "You've changed this foo to be open_with_embargo_release_date") # Leveraging Capybara::Maleficent.with_sleep_injection
     within('.button_to') do

--- a/spec/curate/pages/account_page.rb
+++ b/spec/curate/pages/account_page.rb
@@ -16,7 +16,6 @@ module Curate
       end
 
       def valid_page_content?
-        has_selector?(:link_or_button, "Add a Section to my Profile")
         has_selector?(:link_or_button, "Update Personal Information")
       end
     end

--- a/spec/curate/pages/account_page.rb
+++ b/spec/curate/pages/account_page.rb
@@ -2,7 +2,7 @@
 
 module Curate
   module Pages
-    class MyProfilePage
+    class MyAccountPage
       include Capybara::DSL
       include CapybaraErrorIntel::DSL
 

--- a/spec/curate/pages/edit_work_page.rb
+++ b/spec/curate/pages/edit_work_page.rb
@@ -22,7 +22,7 @@ module Curate
       def has_editable_doi?
         within('#doi') do
           has_content?('Digital Object Identifier')
-          find_link(href: /http.*:\/\/.*datacite.org\/doi:.*\/.*/)
+          find_link(href: /http.*:\/\/.*doi.org\/doi:.*\/.*/)
         end
         # Checks if an editable text box exists
         find('#image_doi')

--- a/spec/curate/pages/faq_page.rb
+++ b/spec/curate/pages/faq_page.rb
@@ -27,7 +27,6 @@ module Curate
       def valid_page_navigation?
         within(".feature-navigation-wrapper") do
           find_link('Help').visible? &&
-            find_link('Getting Started').visible? &&
             find_link('Common Questions').visible?
         end
       end

--- a/spec/curate/pages/image_page.rb
+++ b/spec/curate/pages/image_page.rb
@@ -42,7 +42,7 @@ module Curate
           elsif access_rights == 'embargo'
             choose(id: 'visibility_' + access_rights)
             if embargo_date
-              fill_in(id: 'image_embargo_release_date', with: Date.today + 1)
+              fill_in(id: 'image_embargo_release_date', with: Date.today + 2)
             end
           else
             choose(id: 'visbility_open')

--- a/spec/curate/pages/image_page.rb
+++ b/spec/curate/pages/image_page.rb
@@ -64,6 +64,9 @@ module Curate
           end
         end
         fill_in(id: 'publisher', with: 'foo')
+        # Randomly selects a value from the 'Departments and Units' dropdown
+        dropdown = find('.control-group.Image_administrative_unit').find('#image_administrative_unit_')
+        dropdown.all('option')[rand(11)].select_option
         find('#accept_contributor_agreement').click
         find('.btn.btn-primary.require-contributor-agreement').click
       end

--- a/spec/curate/pages/loggedin_page.rb
+++ b/spec/curate/pages/loggedin_page.rb
@@ -25,7 +25,7 @@ module Curate
         has_content?("My Works")
         has_content?("My Collections")
         has_content?("Group Administration")
-        has_content?("My Profile")
+        has_content?("My Account")
         has_content?("Log Out")
         find("div.btn-group.my-actions").click
       end

--- a/spec/curate/pages/orcid_home_page.rb
+++ b/spec/curate/pages/orcid_home_page.rb
@@ -6,9 +6,9 @@ module Curate
       include Capybara::DSL
       include CapybaraErrorIntel::DSL
 
-      def on_page?(account_details_updated)
+      def on_page?
         on_valid_url? &&
-          valid_page_content?(account_details_updated) &&
+          valid_page_content? &&
           valid_uri_parameters?
       end
 
@@ -16,18 +16,10 @@ module Curate
         Capybara.current_host.include?('orcid.org')
       end
 
-      def valid_page_content?(account_details_updated)
+      def valid_page_content?
         page.has_content?("ORCID")
-        if account_details_updated
-          find('#register-form-password')
-          page.has_selector?(:link_or_button, "Sign In")
-          page.has_selector?(:link_or_button, "Register")
-        else
-          find('#userId.form-control.ng-pristine.ng-untouched.ng-valid.ng-empty')
-          find('#password.form-control')
-          page.has_selector?(:link_or_button, "Register now")
-          page.has_selector?(:link_or_button, "Sign into ORCID")
-        end
+        page.has_selector?(:link_or_button, "Sign In")
+        page.has_selector?(:link_or_button, "Register")
       end
 
       def valid_uri_parameters?

--- a/spec/curate/pages/show_article.rb
+++ b/spec/curate/pages/show_article.rb
@@ -65,7 +65,7 @@ module Curate
       def has_doi?
         has_content?('Digital Object Identifier')
         on_valid_url?
-        find_link(href: /http.*:\/\/.*datacite.org\/doi:.*\/.*/)
+        find_link(href: /http.*:\/\/.*doi.org\/doi:.*\/.*/)
       end
     end
   end


### PR DESCRIPTION
## Changes 'My Profile' to 'My Account'

d6e653ba9aea72a4441efa1ef508046e1d581596

This change is based on the curate changes in https://github.com/ndlib/curate_nd/pull/725/commits/3c7adf251b6f076bd52a90c7bead4b29de46d12c

## Removes assertion for 'Getting Started' link

24ee90a173050c2eaa3a8ad12c5bfa227381df75

based on the curate changes in https://github.com/ndlib/curate_nd/pull/727/commits/efc59b1c2f85c161497cf9ba75082f79f5c364b7

## Removes Curate assertion on Profile page

d9dccddcc7a78fec1db5106d5c9812152aa96fdd

'Add a Section to my Profile' link has been removed in https://github.com/ndlib/curate_nd/pull/725/commits/5b338fa79ac3fd97bfe047a5caba780c4f01680f

## Optimizes ORCID scenarios

df4bfbd30a123b7ea9685c4e3f5ad237ae346d33

This commit conflates the 2 separate scenarios for accounts with and
without details updated. Reasoning:
Previously on clicking 'ORCID logo Create or Connect your ORCID iD',
 accounts that were not updated in CurateND would go to
the ORCID 'Sign In' page and those with updated CurateND accounts
would go to the ORCID 'Register account' page. Now all accounts
go to the same 'ORCID Register account' page.

## Adds 'administrative units' to new deposits

cdc78d5b105f96f8cebfe4d9adc0938992aa85ed

Required due to changes in https://github.com/ndlib/curate_nd/pull/723

## Sets a longer future date for emabargo

afa643a64751986286d0c511564104fe36072640

New deposits are not getting saved as 'Under Embargo' when
they are set with tomorrow's date. This is a workaround.

See https://jira.library.nd.edu/browse/DLTP-1526

## Switches DOI URL back from datacite.org to doi.org

Datacite migration is complete 60f3d9f890b08b4eb57c3e613914dd00842790f8