### PR TITLE
Moves 'has_field?' asertion outside 'within' block

### DIFF
--- a/spec/curate/pages/home_page.rb
+++ b/spec/curate/pages/home_page.rb
@@ -24,9 +24,9 @@ module Curate
       end
 
       def valid_page_content?
+        has_field?('catalog_search', type: 'search')
         within('.homepage-search') do
-          has_field?('catalog_search', type: 'search') &&
-            find_button('keyword-search-submit').visible?
+          find_button('keyword-search-submit').visible?
         end
       end
     end


### PR DESCRIPTION
Sometimes the pprd environment loads slowly and in that case I
need to give the 'valid_page_content?' some breathing room for the
page load to finish. Otherwise I'd see this error:
```console
Unable to find visible css \".homepage-search\
```
Moving this assertion outside the 'within' block
leverages Capybara::Maleficent built in wait logic.
This change reduces the brittleness of the  specs in slow environments