### PR TITLE
Curate fixes for failing specs

### DIFF
--- a/spec/curate/functional/func_curate_spec.rb
+++ b/spec/curate/functional/func_curate_spec.rb
@@ -490,7 +490,9 @@ feature 'Digital Object Identifiers:', js: true do
     visit '/'
     home_page = Curate::Pages::HomePage.new
     expect(home_page).to be_on_page
-    search_term = "desc_metadata__identifier_tesim:*"
+    # This search term returns results for items with ND generated DOIs.
+    # DOIs created from other publishers will not redirect back to the item
+    search_term = "desc_metadata__identifier_tesim:doi:10.7274/r0"
     fill_in('catalog_search', with: search_term)
     click_on('Search')
     item_links = all('a[id^="src_copy_link"]')

--- a/spec/curate/pages/orcid_home_page.rb
+++ b/spec/curate/pages/orcid_home_page.rb
@@ -18,8 +18,6 @@ module Curate
 
       def valid_page_content?
         page.has_content?("ORCID")
-        page.has_selector?(:link_or_button, "Sign In")
-        page.has_selector?(:link_or_button, "Register")
       end
 
       def valid_uri_parameters?


### PR DESCRIPTION
## Refines search term to ND created DOIs

a27ae25515d56ef4e38cb37685b6e349981fa7fd

Only ND created DOI links are expected to redirect back to curateND.
Example: https://curate.nd.edu/show/qf85n87433t
Clicking DOI links created by other publishers will direct the browser
to the publishers content.
Example: https://curate.nd.edu/show/kd17cr59n26

## Removes link/button assertions for orcid page

541ea57d8d04439b71d63b108a729a0da99e1561

Depending on how the testing accounts are setup across different
environments, the orcid redirect page can either be a sign in or registration
page. This keeps changing as we're testing different environments
and introduces unnecessary flux.

With this change I'm loosening up assertions to a point where it
verifies that the redirect was successful to either of the Orcid page.