### PR TITLE
ESU-645: Create Dockerfile and send selenium requests to SauceLabs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.bundle/*
+.byebug_history
+.git
+
+logs/*.log
+tmp/*
+vendor/*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -721,10 +721,10 @@ GEM
     rubocop-rspec (1.15.1)
       rubocop (>= 0.42.0)
     ruby-progressbar (1.8.1)
-    rubyzip (1.2.1)
-    selenium-webdriver (3.12.0)
+    rubyzip (1.2.2)
+    selenium-webdriver (3.14.1)
       childprocess (~> 0.5)
-      rubyzip (~> 1.2)
+      rubyzip (~> 1.2, >= 1.2.2)
     signet (0.7.3)
       addressable (~> 2.3)
       faraday (~> 0.9)
@@ -780,4 +780,4 @@ DEPENDENCIES
   swagger-parser
 
 BUNDLED WITH
-   1.16.1
+   1.16.3

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,32 @@
+FROM ruby:2.3.1
+RUN apt-get update -qq && apt-get install -y build-essential
+
+# Install chamber to get secrets from parameter store
+RUN curl https://github.com/segmentio/chamber/releases/download/v2.2.0/chamber_v2.2.0_amd64.deb --output chamber.deb -L
+RUN dpkg -i chamber.deb
+# We are just using the account's default ssm key to encrypt the values
+# If this changes, we'll need to override this alias
+ENV CHAMBER_KMS_KEY_ALIAS=aws/ssm
+ARG DEFAULT_ENV_SSM_PATH="all/qa/ecs-task-env/prod"
+ENV ENV_SSM_PATH=$DEFAULT_ENV_SSM_PATH
+
+ENV APP_HOME /app_root
+RUN mkdir $APP_HOME
+WORKDIR $APP_HOME
+
+RUN gem install bundler
+COPY Gemfile* $APP_HOME/
+ENV BUNDLE_GEMFILE=$APP_HOME/Gemfile \
+  BUNDLE_JOBS=4 \
+  BUNDLE_PATH=/bundle
+RUN bundle install --without test development
+
+COPY . $APP_HOME
+WORKDIR $APP_HOME
+RUN chmod u+x docker/entry.sh
+
+ENV SKIP_CLOUDWATCH=true
+ENV RUNNING_ON_LOCAL_DEV=true
+
+
+ENTRYPOINT ["bash", "docker/entry.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,26 @@
+# Build
+dockerbuild . -f docker/Dockerfile -t qa_tests
+
+# Running in development
+To run this locally, from the root directory:
+```bash
+docker build . -f docker/Dockerfile -t qa_tests
+docker run \
+  --env AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
+  --env AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
+  --env AWS_SECURITY_TOKEN=$AWS_SECURITY_TOKEN \
+  --env AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN \
+  --env AWS_REGION=$AWS_REGION \
+  --env ENV_SSM_PATH=all/qa/ecs-task-env/prod \
+  --env ENVIRONMENT=prod \
+  --env CHROME_HEADLESS=true \
+  -it qa_tests \
+  spec/bendo/functional/func_bendo_spec.rb
+```
+
+Current SSM expectations:
+
+| Path | Description | Example Create |
+|----|-----------| |
+| $ENV_SSM_PATH/sauce-user | The user name to use when submitting requests to Saucelabs | ```aws ssm put-parameter --name /all/qa/ecs-task-env/prod/sauce-user --type SecureString --overwrite --value saucey-user``` |
+| $ENV_SSM_PATH/sauce-pass | The password to use when submitting requests to Saucelabs | ```aws ssm put-parameter --name /all/qa/ecs-task-env/prod/sauce-pass --type SecureString --overwrite --value saucey-password``` |

--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -1,0 +1,3 @@
+echo Mapping SSM path "$ENV_SSM_PATH" to my environment.
+echo Running tests with the following arguments: "$@"
+exec chamber exec "$ENV_SSM_PATH" -- bundle exec ruby -wU bin/run_tests $@

--- a/spec/spec_support/test_runtime.rb
+++ b/spec/spec_support/test_runtime.rb
@@ -139,25 +139,9 @@ module InitializeExample
     sauce_url.password = ENV['SAUCE_PASS']
     Capybara.register_driver :chrome_headless do |app|
       options = Selenium::WebDriver::Chrome::Options.new
-      options.add_argument('--no-sandbox')
-      options.add_argument('--headless')
-      options.add_argument('--disable-gpu')
-      prefs = {
-        prompt_for_download: false,
-        directory_upgrade: false
-      }
-      profile = {
-        default_content_settings:
-          {
-            popups: 0
-          }
-      }
-      options.add_preference(:download, prefs)
-      options.add_preference(:profile, profile)
-
-      capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-        chromeOptions: options
-      )
+      capabilities = Selenium::WebDriver::Remote::Capabilities.chrome()
+      capabilities['platform'] = 'Windows 7'
+      capabilities['version'] = '67.0'
       Capybara::Selenium::Driver.new(app,
                                      browser: :remote,
                                      url: sauce_url,

--- a/spec/spec_support/test_runtime.rb
+++ b/spec/spec_support/test_runtime.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'fileutils'
+require 'uri'
 
 module RunIdentifier
   # * Provides getter and setter methods to
@@ -133,6 +134,9 @@ module InitializeExample
   end
 
   def self.initialize_chrome_headless_driver
+    sauce_url = URI.join('https://ondemand.saucelabs.com:443/wd/hub')
+    sauce_url.user = ENV['SAUCE_USER']
+    sauce_url.password = ENV['SAUCE_PASS']
     Capybara.register_driver :chrome_headless do |app|
       options = Selenium::WebDriver::Chrome::Options.new
       options.add_argument('--no-sandbox')
@@ -156,7 +160,7 @@ module InitializeExample
       )
       Capybara::Selenium::Driver.new(app,
                                      browser: :remote,
-                                     url: "http://localhost:4444/wd/hub",
+                                     url: sauce_url,
                                      desired_capabilities: capabilities)
     end
   end

--- a/spec/spec_support/test_runtime.rb
+++ b/spec/spec_support/test_runtime.rb
@@ -138,8 +138,7 @@ module InitializeExample
     sauce_url.user = ENV['SAUCE_USER']
     sauce_url.password = ENV['SAUCE_PASS']
     Capybara.register_driver :chrome_headless do |app|
-      options = Selenium::WebDriver::Chrome::Options.new
-      capabilities = Selenium::WebDriver::Remote::Capabilities.chrome()
+      capabilities = Selenium::WebDriver::Remote::Capabilities.chrome
       capabilities['platform'] = 'Windows 7'
       capabilities['version'] = '67.0'
       Capybara::Selenium::Driver.new(app,

--- a/spec/spec_support/test_runtime.rb
+++ b/spec/spec_support/test_runtime.rb
@@ -141,6 +141,7 @@ module InitializeExample
       capabilities = Selenium::WebDriver::Remote::Capabilities.chrome
       capabilities['platform'] = 'Windows 7'
       capabilities['version'] = '67.0'
+      capabilities['recordVideo'] = false
       Capybara::Selenium::Driver.new(app,
                                      browser: :remote,
                                      url: sauce_url,


### PR DESCRIPTION
## Changes the chrome headless driver to target sauce labs infrastructure

d6f4ceeb75fbe489dec086e2ca5be713b15757b7


## Updates selenium-webdriver to newer version

58c39abccc2a357a930bd382882b8fe1a26f491b


## Removes chrome options that sauce labs doesn't need

7c939def396c462e67e647d679ed294443710337


## Makes rubocop happy

bcb2746a6a8edb60a0e5a4d439744f95234a9f54


## Disables video recording by default for chrome on sauce labs

5b6ce217eaf00ed8961fa33f71ba33492cd6bcac


## ESU-687: Create docker image

efba7a18776e42d570919018d2cf9422d6c451b5

- First pass at a dockerfile that will run the ruby rspec application
- Added chamber to the dockerfile in order to read saucelabs secrets from SSM