### PR TITLE
ESU-687: Create docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.bundle/*
+.byebug_history
+.git
+
+logs/*.log
+tmp/*
+vendor/*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,32 @@
+FROM ruby:2.3.1
+RUN apt-get update -qq && apt-get install -y build-essential
+
+# Install chamber to get secrets from parameter store
+RUN curl https://github.com/segmentio/chamber/releases/download/v2.2.0/chamber_v2.2.0_amd64.deb --output chamber.deb -L
+RUN dpkg -i chamber.deb
+# We are just using the account's default ssm key to encrypt the values
+# If this changes, we'll need to override this alias
+ENV CHAMBER_KMS_KEY_ALIAS=aws/ssm
+ARG DEFAULT_ENV_SSM_PATH="all/qa/ecs-task-env/prod"
+ENV ENV_SSM_PATH=$DEFAULT_ENV_SSM_PATH
+
+ENV APP_HOME /app_root
+RUN mkdir $APP_HOME
+WORKDIR $APP_HOME
+
+RUN gem install bundler
+COPY Gemfile* $APP_HOME/
+ENV BUNDLE_GEMFILE=$APP_HOME/Gemfile \
+  BUNDLE_JOBS=4 \
+  BUNDLE_PATH=/bundle
+RUN bundle install --without test development
+
+COPY . $APP_HOME
+WORKDIR $APP_HOME
+RUN chmod u+x docker/entry.sh
+
+ENV SKIP_CLOUDWATCH=true
+ENV RUNNING_ON_LOCAL_DEV=true
+
+
+ENTRYPOINT ["bash", "docker/entry.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,19 @@
+# Build
+dockerbuild . -f docker/Dockerfile -t qa_tests
+
+# Running in development
+To run this locally, from the root directory:
+```bash
+docker build . -f docker/Dockerfile -t qa_tests
+docker run \
+  --env AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
+  --env AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
+  --env AWS_SECURITY_TOKEN=$AWS_SECURITY_TOKEN \
+  --env AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN \
+  --env AWS_REGION=$AWS_REGION \
+  --env ENV_SSM_PATH=all/qa/ecs-task-env/prod \
+  --env ENVIRONMENT=prod \
+  --env CHROME_HEADLESS=true \
+  -it qa_tests \
+  spec/bendo/functional/func_bendo_spec.rb
+```

--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -1,0 +1,3 @@
+echo Mapping SSM path "$ENV_SSM_PATH" to my environment.
+echo Running tests with the following arguments: "$@"
+exec chamber exec "$ENV_SSM_PATH" -- bundle exec ruby -wU bin/run_tests $@


### PR DESCRIPTION
## ESU-687: Create docker image

aa3ff9c2acdcd80267ca6947a7a7f0d90c4521e8

- First pass at a dockerfile that will run the ruby rspec application
- Added chamber to the dockerfile in order to read saucelabs (or other) secrets from SSM