### PR TITLE
Adds support for running specs using sauce labs infrastructure 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -721,10 +721,10 @@ GEM
     rubocop-rspec (1.15.1)
       rubocop (>= 0.42.0)
     ruby-progressbar (1.8.1)
-    rubyzip (1.2.1)
-    selenium-webdriver (3.12.0)
+    rubyzip (1.2.2)
+    selenium-webdriver (3.14.1)
       childprocess (~> 0.5)
-      rubyzip (~> 1.2)
+      rubyzip (~> 1.2, >= 1.2.2)
     signet (0.7.3)
       addressable (~> 2.3)
       faraday (~> 0.9)
@@ -780,4 +780,4 @@ DEPENDENCIES
   swagger-parser
 
 BUNDLED WITH
-   1.16.1
+   1.16.3

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ $ ./bin/run_tests -h
 ```console
 $ cd /path/to/QA_tests
 $ git pull
-$ USE_LOCALHOST_GRID=true SKIP_CLOUDWATCH=true RUNNING_ON_LOCAL_DEV=true bin/run_tests spec/curate/functional/func_curate_spec.rb:6
+$ USE_LOCALHOST_GRID=true SKIP_CLOUDWATCH=true RUNNING_ON_LOCAL_DEV=true bin/run_tests spec/curate/functional/func_curate_spec.rb
 ```
 ### QA developers: Example for running tests from non-master branch using Docker
 ```console

--- a/README.md
+++ b/README.md
@@ -120,13 +120,13 @@ $ ./bin/run_tests -h
 ```console
 $ cd /path/to/QA_tests
 $ git pull
-$ CHROME_HEADLESS=true SKIP_CLOUDWATCH=true RUNNING_ON_LOCAL_DEV=true bin/run_tests spec/curate/functional/func_curate_spec.rb
+$ USE_LOCALHOST_GRID=true SKIP_CLOUDWATCH=true RUNNING_ON_LOCAL_DEV=true bin/run_tests spec/curate/functional/func_curate_spec.rb:6
 ```
 ### QA developers: Example for running tests from non-master branch using Docker
 ```console
 $ git checkout -b <new_dev_branch>
 $ <do development stuff>
-$ CHROME_HEADLESS=true SKIP_CLOUDWATCH=true RUNNING_ON_LOCAL_DEV=true bin/run_tests spec/curate/functional/func_curate_spec.rb
+$ USE_LOCALHOST_GRID=true SKIP_CLOUDWATCH=true RUNNING_ON_LOCAL_DEV=true bin/run_tests spec/curate/functional/func_curate_spec.rb
 ```
 *  Create a PR your local QA_tests branch to merge into master
 *  Wait for qa-tests:latest to be updated on [Docker hub](https://hub.docker.com/r/ndlib/qa-tests/)

--- a/bin/run_tests
+++ b/bin/run_tests
@@ -12,7 +12,7 @@ end
 #
 # *****************************************************************************
 
-CONFIG_KEYS = [:SKIP_AWS_SSM_SETUP, :RUNNING_ON_LOCAL_DEV, :CHROME_HEADLESS, :FIREFOX_HEADLESS, :ENVIRONMENT, :ENVIRONMENT_CATEGORY, :LOG_LEVEL, :SKIP_CLOUDWATCH, :SKIP_VERIFY_NETWORK_TRAFFIC, :SKIP_MALEFICENT, :ALLOW_ALL_NETWORK_HOSTS, :USE_CONTENTFUL_SPACE, :VERSION_NUMBER, :RELEASE_NUMBER].freeze
+CONFIG_KEYS = [:SKIP_AWS_SSM_SETUP, :RUNNING_ON_LOCAL_DEV, :USE_LOCALHOST_GRID, :FIREFOX_HEADLESS, :ENVIRONMENT, :ENVIRONMENT_CATEGORY, :LOG_LEVEL, :SKIP_CLOUDWATCH, :SKIP_VERIFY_NETWORK_TRAFFIC, :SKIP_MALEFICENT, :ALLOW_ALL_NETWORK_HOSTS, :USE_CONTENTFUL_SPACE, :VERSION_NUMBER, :RELEASE_NUMBER].freeze
 
 ENVIRONMENT = ENV.fetch('ENVIRONMENT', Bunyan::DEFAULT_ENVIRONMENT)
 ENVIRONMENT_CATEGORY = ENV.fetch('ENVIRONMENT_CATEGORY', nil)
@@ -25,7 +25,7 @@ USE_CONTENTFUL_SPACE = ENV.fetch('USE_CONTENTFUL_SPACE', nil)
 VERSION_NUMBER = ENV.fetch('VERSION_NUMBER', nil)
 RELEASE_NUMBER = ENV.fetch('RELEASE_NUMBER', nil)
 RUNNING_ON_LOCAL_DEV = ENV.fetch('RUNNING_ON_LOCAL_DEV', nil)
-CHROME_HEADLESS = ENV.fetch('CHROME_HEADLESS', nil)
+USE_LOCALHOST_GRID = ENV.fetch('USE_LOCALHOST_GRID', nil)
 FIREFOX_HEADLESS = ENV.fetch('FIREFOX_HEADLESS', nil)
 SKIP_AWS_SSM_SETUP = ENV.fetch('SKIP_AWS_SSM_SETUP', nil)
 
@@ -132,10 +132,10 @@ if ARGV.grep(/-h/i).size == 1
   $stdout.puts "Example:"
   $stdout.puts "$ SKIP_AWS_SSM_SETUP=true ./bin/#{File.basename(__FILE__)}"
 
-  $stdout.puts "CHROME_HEADLESS: This toggle indicates if you want to run tests using Chrome"
+  $stdout.puts "USE_LOCALHOST_GRID: This toggle indicates if you want to run tests using Chrome on localhost"
   $stdout.puts ""
   $stdout.puts "Example:"
-  $stdout.puts "$ CHROME_HEADLESS=true ./bin/#{File.basename(__FILE__)}"
+  $stdout.puts "$ USE_LOCALHOST_GRID=true ./bin/#{File.basename(__FILE__)}"
 
   $stdout.puts "FIREFOX_HEADLESS: This toggle indicates if you want to run tests using Firefox"
   $stdout.puts ""

--- a/docker/README.md
+++ b/docker/README.md
@@ -13,7 +13,30 @@ docker run \
   --env AWS_REGION=$AWS_REGION \
   --env ENV_SSM_PATH=all/qa/ecs-task-env/prod \
   --env ENVIRONMENT=prod \
-  --env CHROME_HEADLESS=true \
+  --env RUNNING_ON_LOCAL_DEV=true \
+  --env USE_SAUCE_GRID=true \
+  --env PLATFORM='Windows 10' \
+  --env BROWSER_NAME='Internet Explorer' \
+  --env BROWSER_VERSION='11.0' \
   -it qa_tests \
-  spec/bendo/functional/func_bendo_spec.rb
+  spec/curate/functional/func_curate_spec.rb:6
 ```
+
+## Current SSM expectations:
+
+| Path | Description | Example Create |
+|----|-----------|------ |
+| $ENV_SSM_PATH/sauce-user | The user name to use when submitting requests to Saucelabs | ```aws ssm put-parameter --name /all/qa/ecs-task-env/prod/sauce-user --type SecureString --overwrite --value saucey-user``` |
+| $ENV_SSM_PATH/sauce-pass | The password to use when submitting requests to Saucelabs | ```aws ssm put-parameter --name /all/qa/ecs-task-env/prod/sauce-pass --type SecureString --overwrite --value saucey-password``` |
+
+## Desired capabilities
+You can override default platform configurations by passing them as environment variables. Refer Sauce Labs [platform configurator](https://wiki.saucelabs.com/display/DOCS/Platform+Configurator#/) to determine allowed values.
+
+| Variable Name      | Type  | Default |
+|--------------------|-------|---------|
+| PLATFORM           |String | `Windows 10` |
+| BROWSER_NAME       |String | `Chrome`     |
+| BROWSER_VERSION    |String | `70.0` |
+| RECORD_VIDEO       |Boolean| `true` |
+| RECORD_SCREENSHOTS |Boolean| `true` |
+| SCREEN_RESOLUTION  |String |`1024x768` |

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,5 +1,5 @@
 # Build
-dockerbuild . -f docker/Dockerfile -t qa_tests
+docker build . -f docker/Dockerfile -t qa_tests
 
 # Running in development
 To run this locally, from the root directory:

--- a/spec/spec_support/aws_ssm_handler.rb
+++ b/spec/spec_support/aws_ssm_handler.rb
@@ -24,7 +24,6 @@ module AwsSsmHandler
         create_ssm_client_for_assumed_role
       end
     elsif ENV['RUNNING_ON_LOCAL_DEV'] == "false"
-      call_create_creds_in_ecs
       create_ssm_client
     else
       puts "Missing RUNNING_ON_LOCAL_DEV in ENV"
@@ -78,10 +77,13 @@ module AwsSsmHandler
   end
 
   # Creates SSM client for AWS ECS
+  # When the ECS task is running with FARGATE, this method will will see that
+  # the AWS_CONTAINER_CREDENTIALS_RELATIVE_URI variable is available, and it
+  # will use the provided credentials to make calls to the AWS APIs
   # @return [Aws::SSM::Client]
-  # @see https://docs.aws.amazon.com/sdkforruby/api/Aws/SSM/Client.html
+  # @see https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SSM/Client.html
   def self.create_ssm_client
-    @ssm_client = Aws::SSM::Client.new(region: ENV['AWS_REGION'], credentials: @role_credentials)
+    @ssm_client = Aws::SSM::Client.new
   end
 
   # Creates a credentials object for the ECS executing role in AWS


### PR DESCRIPTION
## Adds driver support for testing on SauceLabs

17cb588b63a00d3568efce7fa5003b7a1d50e9fc

* Removes default behavior of testing with poltergeist and phantomjs
* Adds toggles to switch between local grid and selenium grid. This
is essential because SauceLabs cannot access non-public websites at
the moment.
* Removes method for initializing firefox drivers against local grid.
The intent being to just use one chrome instance to develop test specs
and then use sauce labs infrastructure for all other browsers.
* Adds ability to send sauce lab platform config from environment
variables

## Updates typos on build command and table syntax

aec5e077fbba16db9fa64b62fca203fcae4158e5


## Updates AwsSsmHandler to work with ECS Fargate

2cd7dbaccf8e82bbbb7d8d99990c3870844cfd13

`:region`  and `:credentials` are optional arguments when creating an ssm
client. So when this code is running on ECS, I am depending
on the sdk to figure out the credentials via the default credentials
chain.

## Updates documentation to run tests using local grid

5c5cbf5eecd87abb811ef83524a57eb04ec84f8a
