### PR TITLE
Feature/all spec sanity

### DIFF
--- a/spec/dave/functional/func_dave_spec.rb
+++ b/spec/dave/functional/func_dave_spec.rb
@@ -8,7 +8,7 @@ class DaveSite
   # changes in the url resulting from site navigation.
   include Capybara::DSL
   include CapybaraErrorIntel::DSL
-  DEFAULT_DOCUMENT_SLUG = 'MSN-COL_9101'
+  DEFAULT_DOCUMENT_SLUG = 'MSN-COL_9101-1-B'
   DEFUALT_SITE_URL = "http://testlibnd-dave.s3-website-us-east-1.amazonaws.com"
   attr_accessor :document_slug
   attr_reader :site_url
@@ -92,11 +92,10 @@ feature 'View DAVE Artifact', js: true do
   end
   scenario 'Select Specific Page', :read_only do
     visit_home
-    last_page = find_last_page
-    page_number = Random.rand(1..last_page)
+    page_number = Random.rand(1..5)
     node = find('div[class^="Drawer__wrapper"]')
     within(node) do
-      all("a")[page_number].trigger('click')
+      all("div[class^='Artifact__wrapper']")[page_number].click
     end
     check_image_selection(imageNumber: page_number)
   end
@@ -114,7 +113,7 @@ feature 'View DAVE Artifact', js: true do
     visit_home
     two_page_view_url = site.button_link_url(view_type: :two_page)
     within(bottom_document_navbar) do
-      find("a[href='#{two_page_view_url}']").click
+      find("a[href='/#{two_page_view_url}']").click
     end
     expect(page.current_url).to eq(site.current_url_for_view_type(view_type: :two_page))
     last_page = find_last_page
@@ -132,7 +131,7 @@ feature 'View DAVE Artifact', js: true do
     visit_home
     grid_url = site.button_link_url(view_type: :grid)
     within(bottom_document_navbar) do
-      find("a[href='#{grid_url}']").click
+      find("a[href='/#{grid_url}']").click
     end
     expect(page.current_url).to eq(site.current_url_for_view_type(view_type: :grid))
   end
@@ -143,22 +142,20 @@ feature 'View DAVE Artifact', js: true do
     page_number = Random.rand(1..last_page)
     grid_url = site.button_link_url(view_type: :grid)
     within(bottom_document_navbar) do
-      find("a[href='#{grid_url}']").click
+      find("a[href='/#{grid_url}']").click
     end
     expect(page.current_url).to eq(site.current_url_for_view_type(view_type: :grid))
     grid_url = site.button_link_url(view_type: :grid, page: page_number)
     detail_grid_url = grid_url + "/detail"
-    grid_view = find('div[class^="grid_view__grid_view"]')
+    grid_view = find('div[class^="GridView__gridview"]')
     within(grid_view) do
-      find("a[href='#{detail_grid_url}']").trigger('click')
+      find("a[href='/#{detail_grid_url}']").click
     end
+    first_doc = Dave::Pages::FirstDocument.new
+    expect(first_doc).to be_detail_view
     grid_url = site.current_url_for_view_type(view_type: :grid, page: page_number)
     grid_url += "/detail"
     expect(page.current_url).to eq(grid_url)
-    first_doc = Dave::Pages::FirstDocument.new
-    using_wait_time 50 do
-      expect(first_doc).to be_detail_view
-    end
   end
   scenario 'Visit Page from Current Document', :read_only do
     site.visit_from_current_document(page: 1)
@@ -182,7 +179,7 @@ end
 def visit_new_page(page: 0)
   url = site.button_link_url(page: page)
   within(bottom_document_navbar) do
-    find("a[href='#{url}']").click
+    find("a[href='/#{url}']").click
   end
 end
 

--- a/spec/dave/pages/first_document.rb
+++ b/spec/dave/pages/first_document.rb
@@ -24,11 +24,11 @@ module Dave
       end
 
       def check_bottom_bar?
-        bottom_bar = find('div[class^="DigitalArtifact__bottom_bar"]')
+        bottom_bar = find('div[class^="DigitalArtifact__bottomBar"]')
         within(bottom_bar) do
           url = DaveSite.new.button_link_url(page: "1")
           find('select') &&
-            find("a[href='#{url}']")
+            find("a[href='/#{url}']")
         end
       end
 
@@ -41,7 +41,7 @@ module Dave
       end
 
       def check_meta_data?
-        meta_data = find('div[class^="meta_data__wrapper"]')
+        meta_data = find('div[class^="Metadata__content"]')
         within(meta_data) do
           has_content?('Label') &&
             has_content?('Description') &&
@@ -50,7 +50,7 @@ module Dave
       end
 
       def two_page?
-        meta_data = find('div[class^="meta_data__wrapper"]')
+        meta_data = find('div[class^="Metadata__content"]')
         within(meta_data) do
           has_content?('left') &&
             has_content?('right') &&
@@ -61,13 +61,13 @@ module Dave
       end
 
       def detail_view?
-        meta_data = find('div[class^="meta_data__wrapper"]')
-        has_no_field?(meta_data) &&
+        find('div[class^="OpenSeaDragonPage__viewer"]') &&
           check_manipulation_buttons? &&
           check_nav_buttons?
       end
 
       def check_manipulation_buttons?
+        has_content?("find_replace")
         m_buttons = find('ul[class^="OpenSeaDragonControls__controls"]')
         within(m_buttons) do
           find("a[id='zoom-in']") &&
@@ -75,14 +75,14 @@ module Dave
             find("a[id='rotate-left']") &&
             find("a[id='rotate-right']") &&
             find("a[id='full-page']") &&
-            has_content?("find-replace")
+            has_content?("find_replace")
         end
       end
 
       def check_nav_buttons?
         find("div[class^='OpenSeaDragonPrevNext__rightNav']") &&
           find("div[class^='OpenSeaDragonPrevNext__leftNav']") &&
-          find("div[class^='OpenSeaDragonToolbar__hoverSpin']")
+          find("span[class^='OpenSeaDragonToolbar__hoverSpin']")
       end
     end
   end

--- a/spec/dave/pages/first_document.rb
+++ b/spec/dave/pages/first_document.rb
@@ -9,18 +9,12 @@ module Dave
 
       def on_page?
         on_valid_url? &&
-          status_response_ok? &&
           valid_page_content?
       end
 
       def on_valid_url?
         site = DaveSite.new
         current_url == site.current_url_for_view_type
-      end
-
-      def status_response_ok?
-        true
-        # status_code == [0 || 200]
       end
 
       def valid_page_content?

--- a/spec/dec/functional/func_dec_spec.rb
+++ b/spec/dec/functional/func_dec_spec.rb
@@ -3,27 +3,14 @@
 require 'dec/dec_spec_helper'
 
 feature 'User Browsing', js: true do
-  scenario 'DEC_1', :read_only, :smoke_test do
+  scenario 'Select a collection', :read_only, :smoke_test do
     visit '/'
     home_page = Dec::Pages::HomePage.new
     expect(home_page).to be_on_page
-  end
-
-  scenario 'DEC_2', :read_only, :smoke_test do
-    visit '/'
-    home_page = Dec::Pages::HomePage.new
-    expect(home_page).to be_on_page
-    home_page.click_collections_page
-    collections_page = Dec::Pages::CollectionsPage.new
-    expect(collections_page).to be_on_page
-  end
-
-  scenario 'DEC_3', :read_only, :smoke_test do
-    visit '/'
-    home_page = Dec::Pages::HomePage.new
     home_page.click_collections_page
     collections_page = Dec::Pages::CollectionsPage.new
     expect(collections_page).to be_on_page
     collections_page.click_forward_arrow
+    expect(page).to have_selector("div", id: "page-show")
   end
 end

--- a/spec/dec/pages/collections_page.rb
+++ b/spec/dec/pages/collections_page.rb
@@ -19,11 +19,14 @@ module Dec
       end
 
       def valid_page_content?
+        within('.brand-bar') do
+          find('a', exact_text: 'UNIVERSITY of NOTRE DAME')
+        end
         first('h1') &&
-          first('div', text: 'About', visible: true) &&
           first('span', text: 'arrow_forward') &&
           first('span', text: 'menu') &&
-          first('span', text: 'search')
+          first('span', text: 'search') &&
+          !find_all('div.collection-site-path-card').empty?
       end
 
       def click_forward_arrow

--- a/spec/dec/pages/collections_page.rb
+++ b/spec/dec/pages/collections_page.rb
@@ -14,12 +14,8 @@ module Dec
       def on_valid_url?
         # urls are in the format /somehash/some-hyphenated-words
         # we use a regex here to match that and return true
-        str = Capybara.app_host.gsub("\.", "\\.") + '[A-z0-9]{10}/[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$'
-        %r{#{str}}.match(current_url)
-      end
-
-      def status_response_ok?
-        status_code == 200
+        str = Capybara.app_host + '/[A-z0-9]{10}/[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$'
+        %r{#{str}}.match(current_url).is_a?(MatchData)
       end
 
       def valid_page_content?
@@ -31,7 +27,7 @@ module Dec
       end
 
       def click_forward_arrow
-        first('span', text: 'arrow_forward').trigger('click')
+        first('span', text: 'arrow_forward').click
       end
     end
   end

--- a/spec/dec/pages/home_page.rb
+++ b/spec/dec/pages/home_page.rb
@@ -15,17 +15,13 @@ module Dec
         current_url == File.join(Capybara.app_host) || current_url == File.join(Capybara.app_host, '/')
       end
 
-      def status_response_ok?
-        status_code == 200
-      end
-
       def valid_page_content?
         within('.collectionscover') do
           has_css?('span', text: 'Digital Collections')
         end
         within('.brand-bar') do
-          find_link('University of Notre Dame', href: 'http://www.nd.edu') &&
-            find_link('Hesburgh Libraries', href: 'http://library.nd.edu')
+          find('a', exact_text: 'UNIVERSITY of NOTRE DAME') &&
+            find('a', exact_text: 'HESBURGH LIBRARIES')
         end
         first('div', text: 'Featured Collections')
       end

--- a/spec/hathitrust/functional/func_hathitrust_spec.rb
+++ b/spec/hathitrust/functional/func_hathitrust_spec.rb
@@ -7,7 +7,8 @@ feature 'Institutional Login', js: true do
 
   scenario 'Sign in by institution (Notre Dame)', :validates_login, :read_only do
     visit '/'
-    find('#login-button').trigger('click')
+    find('#login-button').click
+    find('#idp').find(:option, 'University of Notre Dame').select_option
     find('.button.continue').click
     login_page.complete_login
     expect(page).to have_link('My Collections')

--- a/spec/hesburghsite/functional/func_hesburghsite_spec.rb
+++ b/spec/hesburghsite/functional/func_hesburghsite_spec.rb
@@ -21,7 +21,6 @@ feature 'User Browsing', js: true do
   end
 
   scenario 'Test 2: Visit Story Index', :read_only do
-    page.driver.browser.js_errors = false # JS erors on some of the pages
     visit '/'
     click_on('Story Index')
     within('.signup') do
@@ -43,7 +42,6 @@ feature 'User Browsing', js: true do
   end
 
   scenario 'Test 3: Click on chapter on Story Index page', :read_only do
-    page.driver.browser.js_errors = false
     visit '/'
     click_on('Story Index')
     click_on('a', text: 'The Early Years')
@@ -73,7 +71,6 @@ feature 'User Browsing', js: true do
     end
   end
   scenario 'Test 4: Click specific story on Story Index page', :read_only do
-    page.driver.browser.js_errors = false
     visit '/'
     click_on('Story Index')
     click_on('Birth and Family')
@@ -99,7 +96,6 @@ feature 'User Browsing', js: true do
     end
   end
   scenario 'Test 5: Visit the Media Gallery page', :read_only do
-    # page.driver.browser.js_errors = false
     visit '/'
     click_on('Media Gallery')
     within('.signup') do
@@ -134,7 +130,6 @@ feature 'User Browsing', js: true do
     end
   end
   scenario 'Test 8: Visit the About page', :read_only do
-    page.driver.browser.js_errors = false
     visit '/'
     click_on('About')
     within('.signup') do

--- a/spec/osf/functional/func_osf_spec.rb
+++ b/spec/osf/functional/func_osf_spec.rb
@@ -8,14 +8,15 @@ feature 'Institutional Login', js: true do
   scenario 'Sign in by institution (Notre Dame)', :read_only do
     visit '/'
     click_on('Sign In')
-    page.has_selector?('#alternative-institution')
-    find('#alternative-institution').click
+    page.has_selector?('#alt-login-inst')
+    find('#alt-login-inst').click
     find('#institution-form-select').click
     page.has_field?('option', text: 'University of Notre Dame')
     page.select('University of Notre Dame')
-    find('input[name=submit]').trigger(:click)
+    find(:css, '#consent-checkbox').set(true)
+    find('#institution-login').click
     login_page.complete_login
-    expect(page).to have_selector('.dropdown-toggle.nav-user-dropdown')
+    expect(page).to have_button('Create new project')
     # This selector is the user dropdown menu that only appears with a successful login
   end
 end

--- a/spec/primo/functional/func_primo_spec.rb
+++ b/spec/primo/functional/func_primo_spec.rb
@@ -4,14 +4,12 @@ require 'primo/primo_spec_helper'
 
 feature 'User browsing', js: true do
   scenario 'Load homepage', :smoke_test, :read_only do
-    page.driver.browser.js_errors = false
     visit '/'
     home_page = Primo::Pages::HomePage.new
     expect(home_page).to be_on_page
   end
 
   scenario 'User searches OneSearch', :read_only do
-    page.driver.browser.js_errors = false
     visit '/'
     home_page = Primo::Pages::HomePage.new
     expect(home_page).to be_on_page
@@ -24,7 +22,6 @@ feature 'User browsing', js: true do
   end
 
   scenario 'User searches NDCatalog', :read_only do
-    page.driver.browser.js_errors = false
     visit '/'
     home_page = Primo::Pages::HomePage.new
     expect(home_page).to be_on_page

--- a/spec/primo/functional/func_primo_spec.rb
+++ b/spec/primo/functional/func_primo_spec.rb
@@ -13,10 +13,10 @@ feature 'User browsing', js: true do
     visit '/'
     home_page = Primo::Pages::HomePage.new
     expect(home_page).to be_on_page
-    expect(home_page).to be_onesearch_tab_activated
     search_term = 'Automated Testing'
-    fill_in('search_field', with: search_term)
-    find_button(id: 'goButton').trigger('click')
+    fill_in('searchBar', with: search_term)
+    # Clicks first item from auto suggest (OneSearch)
+    find('#prm-simple-search').find_all('li')[0].click
     search_results_page = Primo::Pages::SearchResultsPage.new
     expect(search_results_page).to be_on_page
   end
@@ -25,12 +25,10 @@ feature 'User browsing', js: true do
     visit '/'
     home_page = Primo::Pages::HomePage.new
     expect(home_page).to be_on_page
-    # This selects the NDcatalog tab
-    click_on('Search materials held by all Notre Dame campus libraries')
-    expect(home_page).to be_ndcatalog_tab_activated
     search_term = 'Automated Testing'
-    fill_in('search_field', with: search_term)
-    find_button(id: 'goButton').trigger('click')
+    fill_in('searchBar', with: search_term)
+    # Clicks first item from auto suggest (ND Catalog)
+    find('#prm-simple-search').find_all('li')[1].click
     search_results_page = Primo::Pages::SearchResultsPage.new
     expect(search_results_page).to be_on_page
   end

--- a/spec/primo/pages/home_page.rb
+++ b/spec/primo/pages/home_page.rb
@@ -12,23 +12,15 @@ module Primo
 
       def on_page?
         on_valid_url? &&
-          status_response_ok? &&
           valid_page_content?
       end
 
       def on_valid_url?
-        current_url == File.join(Capybara.app_host, '/primo_library/libweb/action/search.do?vid=NDU')
-      end
-
-      def status_response_ok?
-        status_code.to_s.match(/^20[0,1,6]$/)
+        current_url == File.join(Capybara.app_host, '/primo-explore/search?vid=NDU&sortby=rank&lang=en_US')
       end
 
       def valid_page_content?
-        within('#search_box') do
-          find_field(id: 'search_field')
-          find_button(id: 'goButton')
-        end
+        find_field(id: 'searchBar')
       end
 
       def onesearch_tab_activated?

--- a/spec/primo/pages/home_page.rb
+++ b/spec/primo/pages/home_page.rb
@@ -22,16 +22,6 @@ module Primo
       def valid_page_content?
         find_field(id: 'searchBar')
       end
-
-      def onesearch_tab_activated?
-        # Check if the onesearch tab is selected
-        find('a.active.tab.onesearch.EXLSearchTabTitle.EXLSearchTabLABELOneSearch')
-      end
-
-      def ndcatalog_tab_activated?
-        # Check if the NDcatalog tab is selected
-        find('a.active.tab.ndcatalog.EXLSearchTabTitle.EXLSearchTabLABELND.Campus')
-      end
     end
   end
 end

--- a/spec/primo/pages/search_results_page.rb
+++ b/spec/primo/pages/search_results_page.rb
@@ -7,7 +7,6 @@ module Primo
       include CapybaraErrorIntel::DSL
       def on_page?
         on_valid_url? &&
-          status_response_ok? &&
           has_results?
       end
 
@@ -16,15 +15,9 @@ module Primo
         !current_url.match(Capybara.app_host).nil?
       end
 
-      def status_response_ok?
-        status_code.to_s.match(/^20[0,1,6]$/)
-      end
-
       def has_results?
-        page.has_content?('LIMIT RESULTS BY')
-        within('#resultsListNoId') do
-          !find('table#exlidResultsTable').find_all('tr').empty?
-        end
+        page.has_content?('Refine my results')
+        !find_all('h3.item-title').empty?
       end
     end
   end

--- a/spec/primo/primo_config.yml
+++ b/spec/primo/primo_config.yml
@@ -1,2 +1,2 @@
 prep: https://onesearchpprd.library.nd.edu
-prod: http://onesearch.library.nd.edu
+prod: https://onesearch.library.nd.edu

--- a/spec/rbsc/functional/func_rbsc_spec.rb
+++ b/spec/rbsc/functional/func_rbsc_spec.rb
@@ -4,13 +4,11 @@ require 'rbsc/rbsc_spec_helper'
 
 feature 'User Browsing', js: true do
   scenario 'Load homepage', :smoke_test, :read_only do
-    # Setting js_error false will suppress errors coming back from the site and let the tests finish
-    page.driver.browser.js_errors = false
     visit '/'
     expect(page).to have_content 'Rare Books & Special Collections'
     expect(page).to have_content 'List of Finding Aids'
     within('#main-menu') do
-      expect(page).to have_css 'li', count: 6
+      expect(page).to have_css 'li', count: 5
     end
   end
 end

--- a/spec/seaside/functional/func_seaside_spec.rb
+++ b/spec/seaside/functional/func_seaside_spec.rb
@@ -12,7 +12,7 @@ feature 'User Browsing', js: true do
   scenario 'Visit About Seaside - Community Page', :read_only do
     visit '/'
     click_on('About Seaside')
-    find_link('The Community & Building the Portal').trigger('click')
+    find_link('The Community & Building the Portal').click
     community_page = Seaside::Pages::CommunityPage.new
     expect(community_page).to be_on_page
   end
@@ -20,7 +20,7 @@ feature 'User Browsing', js: true do
   scenario 'Visit About Seaside - History Page', :read_only do
     visit '/'
     click_on('About Seaside')
-    find_link(href: '/essays/seaside-history').trigger('click')
+    find_link(href: '/essays/seaside-history').click
     history_page = Seaside::Pages::HistoryPage.new
     expect(history_page).to be_on_page
   end
@@ -28,7 +28,7 @@ feature 'User Browsing', js: true do
   scenario 'Visit About Seaside - Oral History Page', :read_only do
     visit '/'
     click_on('About Seaside')
-    find_link(href: '/essays/oral-histories').trigger('click')
+    find_link(href: '/essays/oral-histories').click
     oral_hist_page = Seaside::Pages::OralHistPage.new
     expect(oral_hist_page).to be_on_page
   end
@@ -36,7 +36,7 @@ feature 'User Browsing', js: true do
   scenario 'Visit About Seaside - All', :read_only do
     visit '/'
     click_on('About Seaside')
-    find_link('All', href: '/about').trigger('click')
+    find_link('All', href: '/about').click
     about_page = Seaside::Pages::AboutPage.new
     expect(about_page).to be_on_page
   end

--- a/spec/sipity/pages/submitted_etd.rb
+++ b/spec/sipity/pages/submitted_etd.rb
@@ -23,7 +23,6 @@ module Sipity
           find("div.btn-group.my-actions").click
         end
         has_content?("My Works")
-        has_content?("My Collections")
         has_content?("Group Administration")
         has_content?("My Account")
         has_content?("Log Out")

--- a/spec/vatican/functional/func_vatican_spec.rb
+++ b/spec/vatican/functional/func_vatican_spec.rb
@@ -3,14 +3,12 @@
 require 'vatican/vatican_spec_helper'
 feature "User Browsing", :read_only, js: true do
   scenario 'Load Homepage' do
-    page.driver.browser.js_errors = false
     visit '/'
     home_page = Vatican::Pages::HomePage.new
     expect(home_page).to be_on_page
   end
 
   scenario 'Go to "How To Use Database" page', :read_only do
-    page.driver.browser.js_errors = false
     visit '/'
     click_on('How To Use the Database')
     instructions_page = Vatican::Pages::InstructionsPage.new
@@ -18,7 +16,6 @@ feature "User Browsing", :read_only, js: true do
   end
 
   scenario 'Load "Search the Database" page', :read_only do
-    page.driver.browser.js_errors = false
     visit '/'
     click_on("Search The Database")
     search_page = Vatican::Pages::SearchPage.new
@@ -26,42 +23,35 @@ feature "User Browsing", :read_only, js: true do
   end
 
   scenario 'Validate navigation menu on search page', :read_only do
-    page.driver.browser.js_errors = false
     visit '/'
     click_on("Search The Database")
     search_page = Vatican::Pages::SearchPage.new
     expect(search_page).to be_on_page
-    within("nav") do
-      expect(page).to have_css "a", count: 7
-    end
   end
 
   scenario 'Check a box in "Search By Topic"', :read_only do
-    page.driver.browser.js_errors = false
     visit '/'
     click_on("Search The Database")
     search_page = Vatican::Pages::SearchPage.new
     expect(search_page).to be_on_page
-    first(:css, "i.material-icons.topic-checkbox").trigger('click')
+    first(:css, "i.material-icons.topic-checkbox").click
     expect(page).to have_content("Catholic Social Teaching")
   end
 
   scenario 'Clear Selected Topic', :read_only do
-    page.driver.browser.js_errors = false
     visit '/'
     click_on("Search The Database")
     search_page = Vatican::Pages::SearchPage.new
     expect(search_page).to be_on_page
-    first(:css, "i.material-icons.topic-checkbox").trigger('click')
+    first(:css, "i.material-icons.topic-checkbox").click
     expect(page).to have_content "Catholic Social Teaching"
     within("div.col-sm-3.left-col") do
-      find_button("Clear").trigger('click')
+      find_button("Clear").click
     end
     expect(page).to have_no_content("Catholic Social Teaching")
   end
 
   scenario 'Search Results Divided into Columns', :read_only do
-    page.driver.browser.js_errors = false
     visit '/'
     click_on("Search The Database")
     search_page = Vatican::Pages::SearchPage.new
@@ -69,7 +59,7 @@ feature "User Browsing", :read_only, js: true do
     node = first(:css, "input")
     node.set("Vatican")
     within("div.col-sm-10") do
-      find_button("search").trigger('click')
+      find_button("search").click
     end
     expect(page).to have_content("Catholic Social Teaching")
     expect(page).to have_content("document(s) found")
@@ -77,7 +67,6 @@ feature "User Browsing", :read_only, js: true do
   end
 
   scenario 'Access Entire Document', :read_only do
-    page.driver.browser.js_errors = false
     visit '/'
     click_on("Search The Database")
     search_page = Vatican::Pages::SearchPage.new
@@ -85,19 +74,18 @@ feature "User Browsing", :read_only, js: true do
     node = first(:css, "input")
     node.set("Vatican")
     within(first("div.col-sm-4")) do
-      find_button("search").trigger('click')
+      find_button("search").click
     end
     expect(page).to have_content("Catholic Social Teaching")
     expect(page).to have_content("document(s) found")
     expect(page).to have_content("International Human Rights Law")
     within("div.search-list.results") do
-      first("a").trigger('click')
+      first("a").click
     end
     expect(page).to have_content("Topics in Document")
   end
 
   scenario 'Sort Newest To Oldest', :read_only do
-    page.driver.browser.js_errors = false
     visit '/'
     click_on("Search The Database")
     search_page = Vatican::Pages::SearchPage.new
@@ -105,12 +93,12 @@ feature "User Browsing", :read_only, js: true do
     node = first(:css, "input")
     node.set("Vatican")
     within(first("div.col-sm-4")) do
-      find_button("search").trigger('click')
+      find_button("search").click
     end
     expect(page).to have_content("Catholic Social Teaching")
     expect(page).to have_content("document(s) found")
     expect(page).to have_content("International Human Rights Law")
-    find('option', text: "Date New-Old").trigger('click')
+    find('option', text: "Date New-Old").click
     expect(page).to have_content("Catholic Social Teaching")
   end
 end

--- a/spec/vatican/pages/home_page.rb
+++ b/spec/vatican/pages/home_page.rb
@@ -8,16 +8,11 @@ module Vatican
 
       def on_page?
         on_valid_url? &&
-          status_response_ok? &&
           valid_page_content?
       end
 
       def on_valid_url?
         current_url == Capybara.app_host || current_url == File.join(Capybara.app_host, '/')
-      end
-
-      def status_response_ok?
-        status_code == 0 || 200
       end
 
       def valid_page_content?

--- a/spec/vatican/pages/instructions_page.rb
+++ b/spec/vatican/pages/instructions_page.rb
@@ -8,18 +8,13 @@ module Vatican
 
       def on_page?
         on_valid_url? &&
-          status_response_ok? &&
           valid_page_content?
       end
 
       def on_valid_url?
         current_url == File.join(Capybara.app_host, 'using')
       end
-
-      def status_response_ok?
-        status_code == 0 || 200
-      end
-
+      
       def valid_page_content?
         page.has_content?("How To Use the Database")
       end

--- a/spec/vatican/pages/instructions_page.rb
+++ b/spec/vatican/pages/instructions_page.rb
@@ -14,7 +14,7 @@ module Vatican
       def on_valid_url?
         current_url == File.join(Capybara.app_host, 'using')
       end
-      
+
       def valid_page_content?
         page.has_content?("How To Use the Database")
       end

--- a/spec/vatican/pages/search_page.rb
+++ b/spec/vatican/pages/search_page.rb
@@ -8,18 +8,13 @@ module Vatican
 
       def on_page?
         on_valid_url? &&
-          status_response_ok? &&
           valid_page_content?
       end
 
       def on_valid_url?
         current_url == File.join(Capybara.app_host, 'search?q=')
       end
-
-      def status_response_ok?
-        status_code == 0 || 200
-      end
-
+      
       def valid_page_content?
         has_field?("SEARCH THE DATABASE")
       end

--- a/spec/vatican/pages/search_page.rb
+++ b/spec/vatican/pages/search_page.rb
@@ -14,7 +14,7 @@ module Vatican
       def on_valid_url?
         current_url == File.join(Capybara.app_host, 'search?q=')
       end
-      
+
       def valid_page_content?
         has_field?("SEARCH THE DATABASE")
       end


### PR DESCRIPTION
## Removes js_error suppression from primo specs, unsupported by selenium

df59ca4fe66ec65d476402254f116058bb4ce72e


## Updates primo specs for home page

ed051b60c38f899a625f325c3c61e05c061fd00b

* Changes the Primo prod URL config to https
* Changes assertions for element ID
* Removes status_code method from homepage assertion, not supported by
selenium driver

## Updates spec/primo for search scenarios

5bd13dfbf446bb02b9264a38832617a8e2affdd1

* Updates page element assertions
* I'm only searching for presence of search results to make tests more
reliable and less flaky

## Removes unused methods

aba408d08c2b91a1a73731c116d22f1ad0d803d7


## Removes status_code assertion from spec/dave, unsupported by selenium

e24fd61f71ef58264a7d919770fe67ce52a604a8


## Removes empty folder spec/dec/integration

d60e536056025d6074986c0caed8f8caab574d00


## Changes link assertions to  tag assertions on spec/dec home page

9865740cb9fd4b4a8750c9d0b4cc5b2837f1cf82


## Corrects regex pattern and removes trigger method call
5a19e97c95d6f30f87ce48df3217b9084c0b5d8e


## Reduces flakiness of spec/dec/pages/collections_page

881d2e82f39f62d2609e415b138e442510d70844

* Adds wait time by leveraging Capybara::Maleficent wait logic
* Checks for existence of cards on the page and removes Ambiguous match
error

## Merges 3 scenarios into 1

0106bb44dc11879736cefa7ef8a7cc45e6fe1f96


## Adds a dropdown selection to spec/hathitrust

e84733cd833beacb55b6ca8569809aaf21ab1bf1


## Removes js_error suppression ffrom fr hesburgh portal specs, unsupported by selenium

98ae9157f68e7797758ea83326a533cecfbcd077


## Removes 'My collections' assertion from sipity spec. This feature has been removed from curateND

38a60a10c31c6f39c4721d4594eb6a657f938f3d


## Updates selectors for osf spec

61d45d2ff7ee3c9bd13f5034174d37a12371d88f


## Updates spec/rbsc for menu items and removes js_errors

7250c362d2f3753e40449f8c7bec49e19aa79d4d


## Changes from trigger method to click in spec/seaside

32ef44cbb8741304fd47d605afdc54d0421e6e24

## Updates spec/dave

f029278ff675efe240c55fd5f1471694ae528c20

* Changes DEFAULT_DOCUMENT_SLUG to `MSN-COL_9101-1-B` because manifest
for `MSN-COL_9101-1` doesn't exist in DAVE
* Updates regex for href with a leading '/'
* Adds `has_selector?` assertions where wait time logic is needed,
leverages Capybara::Maleficent
* In 'Select Specific Page' scenario changes the 'click' call to the
 div wrapper instead of the anchor tag element. Otherwise it fails with
 an error like:
 `Element <a href=\"/0/MSN-COL_9101-1-B/0/1/35\">...</a> is not clickable at point`
* Also changes the randomization to click one of the first five pages
* Removes wait logic from the 'Go to Detail View' scenario
* Updates class names in assertions based on recent application changes