### PR TITLE
ESU-1046 Test Search Components

### DIFF
--- a/spec/usurper/selenium/chrome/run_specs.sh
+++ b/spec/usurper/selenium/chrome/run_specs.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 
 for i in /etc/selenium/spec/* ;
-    do
-        python3 $i
+    do 
+        python3 $i || exit 1
     done

--- a/spec/usurper/selenium/chrome/spec/usurper_selenium_chrome_homepage.py
+++ b/spec/usurper/selenium/chrome/spec/usurper_selenium_chrome_homepage.py
@@ -1,6 +1,5 @@
 import unittest
 import os
-import time
 import sys
 from selenium import webdriver
 from selenium.webdriver import Chrome
@@ -8,11 +7,6 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.support import expected_conditions as expected
 from selenium.webdriver.support.wait import WebDriverWait
-
-# In order to run this in a python3 environment, you'll need to do the following
-# apt-get install python3-pip
-# python3 -m pip install -U selenium
-# run script as: python3 /path/to/script
 
 BaseURL = os.environ.get('BaseURL')
 
@@ -27,13 +21,14 @@ class Usurper_Tests(unittest.TestCase):
 
     def test_homepage(self):
         driver = self.driver
+        driver.implicitly_wait(10)
         driver.get("https://" + BaseURL)
-        # print("Page Title Is: ") + driver.title
         print(''.join(['Page Title is: ',driver.title]))
         self.assertEqual(driver.title, "Hesburgh Libraries")
 
     def test_check_News_link(self):
         driver = self.driver
+        driver.implicitly_wait(10)
         driver.get("https://" + BaseURL)
         news = driver.find_element_by_link_text("News")
         news.click()
@@ -42,6 +37,7 @@ class Usurper_Tests(unittest.TestCase):
 
     def test_check_Events_link(self):
         driver = self.driver
+        driver.implicitly_wait(10)
         driver.get("https://" + BaseURL)
         events = driver.find_element_by_link_text("Events")
         events.click()

--- a/spec/usurper/selenium/chrome/spec/usurper_selenium_chrome_search.py
+++ b/spec/usurper/selenium/chrome/spec/usurper_selenium_chrome_search.py
@@ -1,0 +1,81 @@
+import unittest
+import os
+import time
+import sys
+from selenium import webdriver
+from selenium.webdriver import Chrome
+from selenium.webdriver.common.by import By
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.support import expected_conditions as expected
+from selenium.webdriver.support.wait import WebDriverWait
+from selenium.webdriver.common.keys import Keys
+
+BaseURL = os.environ.get('BaseURL')
+
+class Usurper_Search_Tests(unittest.TestCase):
+
+    def setUp(self):
+        options = Options()
+        options.add_argument('-headless')
+        options.add_argument('--disable-dev-shm-usage')
+        options.add_argument('--no-sandbox')
+        self.driver = Chrome(options=options)
+
+    def test_homepage(self):
+        driver = self.driver
+        driver.implicitly_wait(10)
+        driver.get("https://" + BaseURL)
+        print(''.join(['Page Title is: ',driver.title]))
+        self.assertEqual(driver.title, "Hesburgh Libraries")
+
+    def test_check_onesearch(self):
+        driver = self.driver
+        driver.implicitly_wait(10)
+        driver.get("https://" + BaseURL)
+        driver.find_element_by_xpath('//*[@id="basic-search-field"]').send_keys('Shakespeare')
+        driver.find_element_by_xpath('//*[@id="searchAppliance"]/span/button').click()
+        print(''.join(['Page Title Is: ', driver.title]))
+        self.assertEqual(driver.title, "Shakespeare | Hesburgh Libraries")
+
+    def test_check_nd_catalog(self):
+        driver = self.driver
+        driver.implicitly_wait(10)
+        driver.get("https://" + BaseURL)
+        button = driver.find_element_by_id('selected-search')
+        driver.execute_script("arguments[0].click();", button)
+        search = driver.find_element_by_id('uSearchOption_1')
+        driver.execute_script("arguments[0].click();", search)
+        driver.find_element_by_xpath('//*[@id="basic-search-field"]').send_keys('Shakespeare')
+        driver.find_element_by_xpath('//*[@id="searchAppliance"]/span/button').click()
+        print(''.join(['Page Title Is: ', driver.title]))
+        self.assertEqual(driver.title, "Shakespeare | Hesburgh Libraries")
+
+    def test_check_curate_nd(self):
+        driver = self.driver
+        driver.implicitly_wait(10)
+        driver.get("https://" + BaseURL)
+        button = driver.find_element_by_id('selected-search')
+        driver.execute_script("arguments[0].click();", button)
+        search = driver.find_element_by_id('uSearchOption_2')
+        driver.execute_script("arguments[0].click();", search)
+        driver.find_element_by_id('basic-search-field').send_keys('Shakespeare')
+        driver.find_element_by_xpath('//*[@id="searchAppliance"]/span/button').click()
+        print(''.join(['Page Title Is: ', driver.title]))
+        self.assertEqual(driver.title, "CurateND Search Results")
+
+    def test_check_library_website(self):
+        driver = self.driver
+        driver.implicitly_wait(10)
+        driver.get("https://" + BaseURL)
+        button = driver.find_element_by_id('selected-search')
+        driver.execute_script("arguments[0].click();", button)
+        search = driver.find_element_by_id('uSearchOption_3')
+        driver.execute_script("arguments[0].click();", search)
+        driver.find_element_by_xpath('//*[@id="basic-search-field"]').send_keys('Shakespeare')
+        driver.find_element_by_xpath('//*[@id="searchAppliance"]/span/button').click()
+        print(''.join(['Page Title Is: ', driver.title]))
+        self.assertEqual(driver.title, "Website Search: | Hesburgh Libraries")
+
+suite = unittest.TestLoader().loadTestsFromTestCase(Usurper_Search_Tests)
+result = unittest.TextTestRunner(verbosity=2).run(suite)
+sys.exit(not result.wasSuccessful())


### PR DESCRIPTION
Creating a second test script to include search checks. The method used to find the dropdown and select a new search choice is not elegant and could be fragile, so we will want to keep an eye on failure rates - however it appears to be an issue with `chromedriver`. I will be working on creating a set of Firefox/geckodriver checks - this might solve the dropdown issue and allow us to remove the more fragile tests from `spec/usurper/selenium/chrome/spec/usurper_selenium_chrome_search.py`.

I've also added the `implcitly_wait(10)` to the python scripts to allow the pages to wait for elements but continue on as soon as they are found.

I've also updated the `run_specs.sh` script to exit 1 if any of the scripts fail, without continuing on to any subsequent scripts. This should speed up execution times in the event that something is legitimately wrong in a test scenario.