### PR TITLE
feat(CI): move rubocop check to GitHub Actions

### DIFF
--- a/.github/workflows/rubocop-ci.yml
+++ b/.github/workflows/rubocop-ci.yml
@@ -1,0 +1,20 @@
+name: Run Rubocop
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Ruby 2.6
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+    - name: Build and test with Rake
+      run: |
+        gem install bundler
+        bundle install --jobs 4 --retry 3
+        bundle exec rake


### PR DESCRIPTION
Closes #357 by leveraging GitHub Actions for CI